### PR TITLE
Add Semantic Kernel console chat using ME.AI

### DIFF
--- a/SemanticKernelChat/ChatHistoryService.cs
+++ b/SemanticKernelChat/ChatHistoryService.cs
@@ -1,0 +1,33 @@
+using Microsoft.Extensions.AI;
+
+namespace SemanticKernelChat;
+
+public interface IChatHistoryService
+{
+    IReadOnlyList<ChatMessage> Messages { get; }
+    void AddUserMessage(string text);
+    void AddAssistantMessage(string text);
+}
+
+public class ChatHistoryService : IChatHistoryService
+{
+    private readonly List<ChatMessage> _messages = [];
+
+    public IReadOnlyList<ChatMessage> Messages => _messages;
+
+    public void AddUserMessage(string text)
+    {
+        if (!string.IsNullOrWhiteSpace(text))
+        {
+            _messages.Add(new ChatMessage(ChatRole.User, text));
+        }
+    }
+
+    public void AddAssistantMessage(string text)
+    {
+        if (!string.IsNullOrWhiteSpace(text))
+        {
+            _messages.Add(new ChatMessage(ChatRole.Assistant, text));
+        }
+    }
+}

--- a/SemanticKernelChat/Program.cs
+++ b/SemanticKernelChat/Program.cs
@@ -1,2 +1,46 @@
-﻿// See https://aka.ms/new-console-template for more information
-Console.WriteLine("Hello, World!");
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.AI;
+using Microsoft.SemanticKernel;
+using SemanticKernelChat;
+
+var builder = Host.CreateApplicationBuilder(args);
+
+builder.Logging.AddConsole();
+
+builder.Services.AddChatClient(_ =>
+    new OpenAI.Chat.ChatClient(
+        builder.Configuration["OPENAI_MODEL"] ?? "gpt-3.5-turbo",
+        builder.Configuration["OPENAI_API_KEY"] ?? Environment.GetEnvironmentVariable("OPENAI_API_KEY")
+    ).AsIChatClient());
+
+builder.Services.AddSingleton<IChatHistoryService, ChatHistoryService>();
+
+var host = builder.Build();
+
+var chatClient = host.Services.GetRequiredService<IChatClient>();
+var history = host.Services.GetRequiredService<IChatHistoryService>();
+
+Console.WriteLine("Type 'exit' to quit.");
+
+while (true)
+{
+    Console.Write("You: ");
+    var input = Console.ReadLine();
+    if (string.IsNullOrWhiteSpace(input))
+    {
+        continue;
+    }
+    if (input.Equals("exit", StringComparison.OrdinalIgnoreCase))
+    {
+        break;
+    }
+
+    history.AddUserMessage(input);
+
+    var response = await chatClient.GetResponseAsync(history.Messages);
+    var reply = response.Text;
+    Console.WriteLine($"AI: {reply}");
+    history.AddAssistantMessage(reply);
+}

--- a/SemanticKernelChat/SemanticKernelChat.csproj
+++ b/SemanticKernelChat/SemanticKernelChat.csproj
@@ -7,4 +7,11 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Microsoft.SemanticKernel" Version="1.55.0" />
+    <PackageReference Include="Microsoft.Extensions.AI.Abstractions" Version="9.5.0" />
+    <PackageReference Include="Microsoft.Extensions.AI.OpenAI" Version="9.5.0-preview.1.25265.7" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.1" />
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
## Summary
- add chat history service
- integrate Semantic Kernel console chat with ME.AI
- register chat client and history using dependency injection

## Testing
- `dotnet build AiWithMcp.sln`
- `dotnet test AiWithMcp.sln`


------
https://chatgpt.com/codex/tasks/task_e_68427372f3548330a5d8519d1fe03864