### PR TITLE
Fix multiline input clearing

### DIFF
--- a/SemanticKernelChat/ChatCommand.cs
+++ b/SemanticKernelChat/ChatCommand.cs
@@ -29,14 +29,22 @@ public sealed class ChatCommand : AsyncCommand<ChatCommand.Settings>
         var tools = toolCollection.Tools;
         ChatConsole.Initialize(tools);
 
-        AnsiConsole.MarkupLine("Type 'exit' to quit.");
+        AnsiConsole.MarkupLine(CliConstants.WelcomeMessage);
 
         while (true)
         {
+            var (style, headerText) = ChatConsole.GetPanelConfig(ChatRole.User);
+            var rule = new Rule(headerText) { Style = style };
+            AnsiConsole.Write(rule);
             AnsiConsole.Markup("You: ");
             var input = await ChatConsole.ReadMultilineInputAsync();
 
-            if (input is null || input.Equals("exit", StringComparison.OrdinalIgnoreCase))
+            if (input is null)
+            {
+                break;
+            }
+
+            if (input.Equals("exit", StringComparison.OrdinalIgnoreCase))
             {
                 break;
             }
@@ -46,8 +54,7 @@ public sealed class ChatCommand : AsyncCommand<ChatCommand.Settings>
                 continue;
             }
 
-            var userMessage = new ChatMessage(ChatRole.User, input);
-            ChatConsole.WriteChatMessages(_history, userMessage);
+            _history.AddUserMessage(input);
 
             await ChatConsole.SendAndDisplayAsync(_chatClient, _history, tools);
         }

--- a/SemanticKernelChat/ChatStreamCommand.cs
+++ b/SemanticKernelChat/ChatStreamCommand.cs
@@ -25,10 +25,13 @@ public sealed class ChatStreamCommand : AsyncCommand<ChatCommand.Settings>
         var tools = toolCollection.Tools;
         ChatConsole.Initialize(tools);
 
-        AnsiConsole.MarkupLine("Type 'exit' to quit.");
+        AnsiConsole.MarkupLine(CliConstants.WelcomeMessage);
 
         while (true)
         {
+            var (style, headerText) = ChatConsole.GetPanelConfig(ChatRole.User);
+            var rule = new Rule(headerText) { Style = style };
+            AnsiConsole.Write(rule);
             AnsiConsole.Markup("You: ");
             var input = await ChatConsole.ReadMultilineInputAsync();
 
@@ -47,12 +50,12 @@ public sealed class ChatStreamCommand : AsyncCommand<ChatCommand.Settings>
                 break;
             }
 
-            var userMessage = new ChatMessage(ChatRole.User, input);
-            ChatConsole.WriteChatMessages(_history, userMessage);
+            _history.AddUserMessage(input);
 
             await ChatConsole.SendAndDisplayStreamingAsync(_chatClient, _history, tools);
         }
 
         return 0;
     }
+
 }

--- a/SemanticKernelChat/CliConstants.cs
+++ b/SemanticKernelChat/CliConstants.cs
@@ -1,0 +1,7 @@
+namespace SemanticKernelChat;
+
+internal static class CliConstants
+{
+    public const string WelcomeMessage =
+        "[grey]Welcome to ConsoleChat! Use Shift+Enter for a new line. Type 'exit' on an empty line to quit.[/]";
+}


### PR DESCRIPTION
## Summary
- keep welcome message and add rule before multiline editor
- remove input clearing helper and just store user messages in history
- don't render user messages a second time

## Testing
- `dotnet test ConsoleChat.sln -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_684b621a460883308065749c53ff5d95