### PR TITLE
Add ChatConsole unit tests

### DIFF
--- a/ConsoleChat.Tests/ChatConsoleTests.cs
+++ b/ConsoleChat.Tests/ChatConsoleTests.cs
@@ -1,0 +1,109 @@
+using System.Runtime.CompilerServices;
+using Microsoft.Extensions.AI;
+using ModelContextProtocol.Client;
+using Spectre.Console;
+using Spectre.Console.Testing;
+using SemanticKernelChat;
+
+namespace ConsoleChat.Tests;
+
+public class ChatConsoleTests
+{
+    private sealed class FakeChatClient : IChatClient
+    {
+        public ChatResponse Response { get; set; } = new(new ChatMessage(ChatRole.Assistant, "reply"));
+        public List<ChatResponseUpdate> StreamingUpdates { get; } = new();
+
+        public Task<ChatResponse> GetResponseAsync(IEnumerable<ChatMessage> messages, ChatOptions? options = null, CancellationToken cancellationToken = default)
+            => Task.FromResult(Response);
+
+        public async IAsyncEnumerable<ChatResponseUpdate> GetStreamingResponseAsync(IEnumerable<ChatMessage> messages, ChatOptions? options = null, [EnumeratorCancellation] CancellationToken cancellationToken = default)
+        {
+            foreach (var update in StreamingUpdates)
+            {
+                yield return update;
+                await Task.Yield();
+            }
+        }
+
+        public object? GetService(Type serviceType, object? serviceKey) => null;
+        public void Dispose() { }
+    }
+
+    [Fact]
+    public void GetUserStyle_Returns_Values_For_User()
+    {
+        var (header, j, style) = SemanticKernelChat.Console.ChatConsole.GetUserStyle(ChatRole.User);
+        Assert.StartsWith(":bust_in_silhouette: User", header);
+        Assert.Equal(Justify.Left, j);
+        Assert.Equal(Color.RoyalBlue1, style.Foreground);
+    }
+
+    [Fact]
+    public void GetUserStyle_Returns_Values_For_Assistant()
+    {
+        var (header, j, style) = SemanticKernelChat.Console.ChatConsole.GetUserStyle(ChatRole.Assistant);
+        Assert.StartsWith(":robot: Assistant", header);
+        Assert.Equal(Justify.Right, j);
+        Assert.Equal(Color.DarkSeaGreen2, style.Foreground);
+    }
+
+    [Fact]
+    public void GetUserStyle_Returns_Values_For_Tool()
+    {
+        var (header, j, style) = SemanticKernelChat.Console.ChatConsole.GetUserStyle(ChatRole.Tool);
+        Assert.StartsWith(":wrench: Tool", header);
+        Assert.Equal(Justify.Center, j);
+        Assert.Equal(Color.Grey37, style.Foreground);
+    }
+
+    [Fact]
+    public void WriteChatMessages_Writes_To_History_And_Console()
+    {
+        var history = new ChatHistoryService();
+        var testConsole = new TestConsole();
+        AnsiConsole.Console = testConsole;
+
+        var msg = new ChatMessage(ChatRole.User, "hello");
+        SemanticKernelChat.Console.ChatConsole.WriteChatMessages(history, msg);
+
+        Assert.Contains(msg, history.Messages);
+        Assert.Contains("hello", testConsole.Output);
+    }
+
+    [Fact]
+    public async Task SendAndDisplayAsync_Writes_Response()
+    {
+        var history = new ChatHistoryService();
+        history.AddUserMessage("hi");
+
+        var testConsole = new TestConsole();
+        AnsiConsole.Console = testConsole;
+
+        var client = new FakeChatClient { Response = new(new ChatMessage(ChatRole.Assistant, "done")) };
+        await SemanticKernelChat.Console.ChatConsole.SendAndDisplayAsync(client, history, Array.Empty<McpClientTool>());
+
+        Assert.Equal(2, history.Messages.Count);
+        Assert.Contains("done", testConsole.Output);
+    }
+
+    [Fact]
+    public async Task SendAndDisplayStreamingAsync_Writes_Updates()
+    {
+        var history = new ChatHistoryService();
+        history.AddUserMessage("hi");
+
+        var testConsole = new TestConsole();
+        AnsiConsole.Console = testConsole;
+
+        var client = new FakeChatClient();
+        client.StreamingUpdates.Add(new ChatResponseUpdate(ChatRole.Assistant, "A"));
+        client.StreamingUpdates.Add(new ChatResponseUpdate(ChatRole.Assistant, "B"));
+
+        await SemanticKernelChat.Console.ChatConsole.SendAndDisplayStreamingAsync(client, history, Array.Empty<McpClientTool>());
+
+        Assert.Equal(2, history.Messages.Count);
+        Assert.Contains("AB", history.Messages.Last().Text);
+        Assert.Contains("AB", testConsole.Output);
+    }
+}

--- a/ConsoleChat.Tests/ConsoleChat.Tests.csproj
+++ b/ConsoleChat.Tests/ConsoleChat.Tests.csproj
@@ -20,6 +20,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
+    <PackageReference Include="Spectre.Console.Testing" Version="0.48.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/SemanticKernelChat/AssemblyInfo.cs
+++ b/SemanticKernelChat/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("ConsoleChat.Tests")]


### PR DESCRIPTION
## Summary
- add Spectre.Console.Testing reference
- expose internals to tests
- create new ChatConsole unit tests

## Testing
- `dotnet test ConsoleChat.sln -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_684e636d226c83309ceb442304b4bc85