### PR TITLE
Await Bedrock client creation

### DIFF
--- a/SemanticKernelChat/Infrastructure/SemanticKernelExtensions.cs
+++ b/SemanticKernelChat/Infrastructure/SemanticKernelExtensions.cs
@@ -15,12 +15,12 @@ public static class SemanticKernelExtensions
     /// <summary>
     /// Registers the Semantic Kernel chat client and related services.
     /// </summary>
-    public static IServiceCollection AddSemanticKernelChatClient(
+    public static async Task<IServiceCollection> AddSemanticKernelChatClient(
         this IServiceCollection services,
         IConfiguration configuration)
     {
         // Create the chat client using configuration
-        IChatClient chatClient = CreateChatClient(configuration);
+        IChatClient chatClient = await CreateChatClientAsync(configuration).ConfigureAwait(false);
 
         // Register the chat client with function invocation support
         _ = services.AddChatClient(_ =>
@@ -35,7 +35,7 @@ public static class SemanticKernelExtensions
     /// <summary>
     /// Creates an IChatClient based on the configured provider (AwsBedrock or OpenAI).
     /// </summary>
-    private static IChatClient CreateChatClient(IConfiguration configuration)
+    private static async Task<IChatClient> CreateChatClientAsync(IConfiguration configuration)
     {
         // Get provider and model configuration. If either is missing, return an echo client.
         var provider = configuration["Provider"];
@@ -53,7 +53,7 @@ public static class SemanticKernelExtensions
         {
             case "AwsBedrock":
                 // Create Bedrock runtime client and wrap as IChatClient
-                var bedrockRuntime = Helpers.BedrockHelper.GetBedrockRuntimeAsync(providerSection).GetAwaiter().GetResult();
+                AmazonBedrockRuntimeClient bedrockRuntime = await Helpers.BedrockHelper.GetBedrockRuntimeAsync(providerSection).ConfigureAwait(false);
                 return bedrockRuntime.AsIChatClient(
                     modelId
                 );

--- a/SemanticKernelChat/Program.cs
+++ b/SemanticKernelChat/Program.cs
@@ -13,7 +13,7 @@ var builder = Host.CreateApplicationBuilder(args);
 
 builder.Logging.AddConsole();
 
-builder.Services.AddSemanticKernelChatClient(builder.Configuration);
+await builder.Services.AddSemanticKernelChatClient(builder.Configuration);
 builder.Services.AddSingleton<IChatHistoryService, ChatHistoryService>();
 
 var registrar = new TypeRegistrar(builder.Services);


### PR DESCRIPTION
## Summary
- make SemanticKernelExtensions async and await Bedrock runtime creation
- await AddSemanticKernelChatClient in Program

## Testing
- `dotnet restore ConsoleChat.sln`
- `dotnet build ConsoleChat.sln`
- `dotnet test ConsoleChat.sln -v minimal`


------
https://chatgpt.com/codex/tasks/task_e_6852241a30c48330a7fe7f33cf84d650