### PR TITLE
Remove unused logger fields

### DIFF
--- a/SemanticKernelChat/Commands/ChatCommand.cs
+++ b/SemanticKernelChat/Commands/ChatCommand.cs
@@ -1,5 +1,4 @@
 using Microsoft.Extensions.AI;
-using Microsoft.Extensions.Logging;
 using SemanticKernelChat.Console;
 using SemanticKernelChat.Infrastructure;
 using Spectre.Console;
@@ -11,17 +10,15 @@ public sealed class ChatCommand : AsyncCommand<ChatCommand.Settings>
 {
     private readonly IChatClient _chatClient;
     private readonly IChatHistoryService _history;
-    private readonly ILogger<ChatCommand> _logger;
 
     public sealed class Settings : CommandSettings
     {
     }
 
-    public ChatCommand(IChatClient chatClient, IChatHistoryService history, ILogger<ChatCommand> logger)
+    public ChatCommand(IChatClient chatClient, IChatHistoryService history)
     {
         _chatClient = chatClient;
         _history = history;
-        _logger = logger;
     }
 
     public override async Task<int> ExecuteAsync(CommandContext context, Settings settings)

--- a/SemanticKernelChat/Commands/ChatStreamCommand.cs
+++ b/SemanticKernelChat/Commands/ChatStreamCommand.cs
@@ -1,5 +1,4 @@
 using Microsoft.Extensions.AI;
-using Microsoft.Extensions.Logging;
 using SemanticKernelChat.Console;
 using SemanticKernelChat.Infrastructure;
 using Spectre.Console;
@@ -11,13 +10,11 @@ public sealed class ChatStreamCommand : AsyncCommand<ChatCommand.Settings>
 {
     private readonly IChatClient _chatClient;
     private readonly IChatHistoryService _history;
-    private readonly ILogger<ChatStreamCommand> _logger;
 
-    public ChatStreamCommand(IChatClient chatClient, IChatHistoryService history, ILogger<ChatStreamCommand> logger)
+    public ChatStreamCommand(IChatClient chatClient, IChatHistoryService history)
     {
         _chatClient = chatClient;
         _history = history;
-        _logger = logger;
     }
 
     public override async Task<int> ExecuteAsync(CommandContext context, ChatCommand.Settings settings)

--- a/SemanticKernelChat/Commands/TextCompletionCommand.cs
+++ b/SemanticKernelChat/Commands/TextCompletionCommand.cs
@@ -1,5 +1,4 @@
 using Microsoft.Extensions.AI;
-using Microsoft.Extensions.Logging;
 using SemanticKernelChat.Infrastructure;
 using Spectre.Console.Cli;
 
@@ -20,12 +19,10 @@ Never guess tool results or add extra text.
 """;
 
     private readonly IChatClient _chatClient;
-    private readonly ILogger<TextCompletionCommand> _logger;
 
-    public TextCompletionCommand(IChatClient chatClient, ILogger<TextCompletionCommand> logger)
+    public TextCompletionCommand(IChatClient chatClient)
     {
         _chatClient = chatClient;
-        _logger = logger;
     }
 
     public override async Task<int> ExecuteAsync(CommandContext context, Settings settings)


### PR DESCRIPTION
## Summary
- drop `_logger` from ChatCommand, ChatStreamCommand and TextCompletionCommand
- update constructors to remove ILogger dependency

## Testing
- `dotnet restore ConsoleChat.sln`
- `dotnet build ConsoleChat.sln`
- `dotnet test ConsoleChat.sln -v minimal`


------
https://chatgpt.com/codex/tasks/task_e_6852249018d08330a38c7b9228916ae1