### PR TITLE
Use AWS credential chain for Bedrock helper

### DIFF
--- a/SemanticKernelChat/Helpers/BedrockHelper.cs
+++ b/SemanticKernelChat/Helpers/BedrockHelper.cs
@@ -15,35 +15,22 @@ namespace SemanticKernelChat.Helpers
         /// </summary>
         /// <param name="config">Configuration section containing RoleArn and credentials profile.</param>
         /// <returns>AmazonBedrockRuntimeClient with temporary credentials.</returns>
-        public static async Task<AmazonBedrockRuntimeClient> GetBedrockRuntimeAsync(IConfiguration config)
+        public static Task<AmazonBedrockRuntimeClient> GetBedrockRuntimeAsync(IConfiguration config)
         {
-            // Get AWS credentials from the shared credentials file (default profile)
-            var awsCredentials = new Amazon.Runtime.CredentialManagement.SharedCredentialsFile();
-            var chain = new Amazon.Runtime.CredentialManagement.CredentialProfileStoreChain();
-            chain.TryGetAWSCredentials("default", out var dev);
+            // Load AWS credentials using the default provider chain
+            var baseCredentials = Amazon.Runtime.Credentials.DefaultAWSCredentialsIdentityResolver.GetCredentials();
 
-            // Prepare to assume the specified role
-            var roleArn = config["RoleArn"];
-            var roleSessionName = $"{Environment.MachineName}-{DateTime.UtcNow:yyyyMMdd'T'HHmmss'Z'}";
+            // Assume the specified role using automatic credential refreshing
+            var assumeRoleCredentials = new Amazon.Runtime.AssumeRoleAWSCredentials(
+                baseCredentials,
+                config["RoleArn"],
+                $"{Environment.MachineName}-{DateTime.UtcNow:yyyyMMdd'T'HHmmss'Z'}"
+            );
 
-            // Create STS client and assume the role
-            var stsClient = new Amazon.SecurityToken.AmazonSecurityTokenServiceClient(dev, RegionEndpoint.USEast1);
-            var assumeRoleRequest = new Amazon.SecurityToken.Model.AssumeRoleRequest
-            {
-                RoleArn = roleArn,
-                RoleSessionName = roleSessionName
-            };
-            var assumeResponse = await stsClient.AssumeRoleAsync(assumeRoleRequest).ConfigureAwait(false);
-            var credentials = assumeResponse.Credentials;
+            // Create Bedrock runtime client with the assumed role credentials
+            var bedrockRuntime = new AmazonBedrockRuntimeClient(assumeRoleCredentials, RegionEndpoint.USEast1);
 
-            // Create Bedrock runtime client with temporary credentials
-            var bedrockRuntime = new AmazonBedrockRuntimeClient(new Amazon.Runtime.SessionAWSCredentials(
-                credentials.AccessKeyId,
-                credentials.SecretAccessKey,
-                credentials.SessionToken
-            ), RegionEndpoint.USEast1);
-
-            return bedrockRuntime;
+            return Task.FromResult(bedrockRuntime);
         }
     }
 }


### PR DESCRIPTION
## Summary
- switch BedrockHelper to the AWS SDK's default credential resolver
- use `AssumeRoleAWSCredentials` for automatic role refresh

## Testing
- `dotnet restore ConsoleChat.sln`
- `dotnet build ConsoleChat.sln`
- `dotnet test ConsoleChat.sln -v minimal`


------
https://chatgpt.com/codex/tasks/task_e_6852242346e0833096e116641bb0ccff