### PR TITLE
Refactor CreateTransports to async

### DIFF
--- a/SemanticKernelChat/Helpers/McpClientHelper.cs
+++ b/SemanticKernelChat/Helpers/McpClientHelper.cs
@@ -3,6 +3,8 @@ using System.Collections.ObjectModel;
 using System.Net;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using System.Threading;
+using System.Runtime.CompilerServices;
 
 using Microsoft.Extensions.Configuration;
 
@@ -29,7 +31,8 @@ public static class McpClientHelper
 {
     public static async IAsyncEnumerable<IClientTransport> CreateTransportsAsync(
         IConfiguration configuration,
-        IHttpClientFactory? httpClientFactory = null)
+        IHttpClientFactory? httpClientFactory = null,
+        [EnumeratorCancellation] CancellationToken cancellationToken = default)
     {
         var servers = configuration.GetSection("McpServers")
             .Get<Dictionary<string, McpServerConfig>>();
@@ -67,7 +70,9 @@ public static class McpClientHelper
                     var http = httpClientFactory?.CreateClient() ?? new HttpClient();
                     try
                     {
-                        var response = await http.SendAsync(new HttpRequestMessage(HttpMethod.Head, serverConfig.Command));
+                        var response = await http.SendAsync(
+                            new HttpRequestMessage(HttpMethod.Head, serverConfig.Command),
+                            cancellationToken);
                         if (response.StatusCode is HttpStatusCode.Unauthorized or HttpStatusCode.Forbidden)
                         {
                             throw new InvalidOperationException($"SSE endpoint '{serverConfig.Command}' requires authentication.");

--- a/SemanticKernelChat/Infrastructure/McpToolCollection.cs
+++ b/SemanticKernelChat/Infrastructure/McpToolCollection.cs
@@ -20,7 +20,7 @@ public sealed class McpToolCollection : IAsyncDisposable
     /// <summary>
     /// Launches MCP servers, retrieves tools, and returns a disposable collection.
     /// </summary>
-    public static async Task<McpToolCollection> CreateAsync()
+    public static async Task<McpToolCollection> CreateAsync(CancellationToken cancellationToken = default)
     {
         var collection = new McpToolCollection();
         var configuration = new ConfigurationBuilder()
@@ -34,7 +34,7 @@ public sealed class McpToolCollection : IAsyncDisposable
         var httpClientFactory = provider.GetRequiredService<IHttpClientFactory>();
 
         var transports = new List<IClientTransport>();
-        await foreach (var transport in McpClientHelper.CreateTransportsAsync(configuration, httpClientFactory))
+        await foreach (var transport in McpClientHelper.CreateTransportsAsync(configuration, httpClientFactory, cancellationToken))
         {
             transports.Add(transport);
         }


### PR DESCRIPTION
## Summary
- support async transport creation
- consume async transports when loading MCP tools

## Testing
- `dotnet build ConsoleChat.sln`
- `dotnet test ConsoleChat.sln -v minimal`


------
https://chatgpt.com/codex/tasks/task_e_685230a182b48330b0a2ac49a08483e3