### PR TITLE
Inject console interface and refactor ChatConsole

### DIFF
--- a/SemanticKernelChat/Console/ChatConsole.cs
+++ b/SemanticKernelChat/Console/ChatConsole.cs
@@ -10,10 +10,12 @@ namespace SemanticKernelChat.Console;
 public class ChatConsole : IChatConsole
 {
     private readonly IChatLineEditor _editor;
+    private readonly IAnsiConsole _console;
 
-    public ChatConsole(IChatLineEditor editor)
+    public ChatConsole(IChatLineEditor editor, IAnsiConsole console)
     {
         _editor = editor;
+        _console = console;
     }
 
     public static (string headerText, Justify justify, Style style) GetUserStyle(ChatRole messageRole)
@@ -106,7 +108,7 @@ public class ChatConsole : IChatConsole
             var (headerText, justify, style) = GetUserStyle(message.Role);
             var header = new PanelHeader(headerText, justify);
 
-            AnsiConsole.Write(
+            _console.Write(
                 new Panel(markupResponse)
                     .RoundedBorder()
                     .BorderStyle(style)
@@ -126,66 +128,76 @@ public class ChatConsole : IChatConsole
 
     public async Task DisplayThinkingIndicator(Func<Task> action)
     {
-        await AnsiConsole.Status()
+        await _console.Status()
             .Spinner(Spinner.Known.Monkey)
             .StartAsync("Thinking...", async _ => await action());
     }
 
     public void DisplayError(Exception ex)
     {
-        AnsiConsole.WriteException(ex, ExceptionFormats.ShortenEverything);
+        _console.WriteException(ex, ExceptionFormats.ShortenEverything);
     }
 
     public async Task<IReadOnlyList<ChatMessage>> DisplayStreamingUpdatesAsync(
-       IAsyncEnumerable<ChatResponseUpdate> updates)
+        IAsyncEnumerable<ChatResponseUpdate> updates)
     {
         var messageUpdates = new List<ChatResponseUpdate>();
         var paragraph = new Paragraph(string.Empty);
-
-        var (headerText, justify, style) = GetUserStyle(ChatRole.Assistant);
-        var header = new PanelHeader(headerText, justify);
-
-        var panel = new Panel(paragraph)
-            .RoundedBorder()
-            .BorderStyle(style)
-            .Header(header)
-            .Expand();
+        var panel = CreateAssistantPanel(paragraph);
 
         var callNames = new Dictionary<string, string>();
-        await AnsiConsole.Live(panel)
+        await _console.Live(panel)
             .AutoClear(false)
             .StartAsync(async ctx =>
             {
                 await foreach (var update in updates)
                 {
                     messageUpdates.Add(update);
-
-                    var contents = update.Contents ?? Array.Empty<AIContent>();
-                    CollectFunctionCallNames(contents, callNames);
-
-                    if (update.Role == ChatRole.Assistant)
-                    {
-                        _ = paragraph.Append(update.Text.EscapeMarkup());
-                    }
-
-                    foreach (var result in contents.OfType<FunctionResultContent>())
-                    {
-                        _ = paragraph.Append("\n");
-                        string toolName = update.AuthorName ?? update.Role.ToString();
-                        var id = result.CallId;
-                        if (!string.IsNullOrEmpty(id) && callNames.TryGetValue(id, out var nameFound))
-                        {
-                            toolName = nameFound;
-                        }
-
-                        _ = paragraph.Append($"[grey]:wrench: {toolName} Result...[/]");
-                    }
-
+                    AppendUpdate(paragraph, callNames, update);
                     ctx.Refresh();
                 }
             });
 
         var response = Microsoft.Extensions.AI.ChatResponseExtensions.ToChatResponse(messageUpdates);
         return [.. response.Messages];
+    }
+
+    private static Panel CreateAssistantPanel(Paragraph paragraph)
+    {
+        var (headerText, justify, style) = GetUserStyle(ChatRole.Assistant);
+        var header = new PanelHeader(headerText, justify);
+
+        return new Panel(paragraph)
+            .RoundedBorder()
+            .BorderStyle(style)
+            .Header(header)
+            .Expand();
+    }
+
+    private static void AppendUpdate(
+        Paragraph paragraph,
+        Dictionary<string, string> callNames,
+        ChatResponseUpdate update)
+    {
+        var contents = update.Contents ?? Array.Empty<AIContent>();
+        CollectFunctionCallNames(contents, callNames);
+
+        if (update.Role == ChatRole.Assistant)
+        {
+            _ = paragraph.Append(update.Text.EscapeMarkup());
+        }
+
+        foreach (var result in contents.OfType<FunctionResultContent>())
+        {
+            _ = paragraph.Append("\n");
+            string toolName = update.AuthorName ?? update.Role.ToString();
+            var id = result.CallId;
+            if (!string.IsNullOrEmpty(id) && callNames.TryGetValue(id, out var nameFound))
+            {
+                toolName = nameFound;
+            }
+
+            _ = paragraph.Append($"[grey]:wrench: {toolName} Result...[/]");
+        }
     }
 }

--- a/SemanticKernelChat/Helpers/McpClientHelper.cs
+++ b/SemanticKernelChat/Helpers/McpClientHelper.cs
@@ -64,6 +64,7 @@ public static class McpClientHelper
                         Command = serverConfig.Command,
                         Arguments = serverConfig.Arguments,
                         EnvironmentVariables = serverConfig.EnvironmentVariables,
+                        WorkingDirectory = AppContext.BaseDirectory,
                     });
                     break;
                 case McpServerTypes.Sse:

--- a/SemanticKernelChat/Program.cs
+++ b/SemanticKernelChat/Program.cs
@@ -19,6 +19,7 @@ builder.Services.AddSingleton<IChatHistoryService, ChatHistoryService>();
 var toolCollection = await McpToolCollection.CreateAsync();
 builder.Services.AddSingleton(toolCollection);
 builder.Services.AddSingleton<IChatLineEditor, ChatLineEditor>();
+builder.Services.AddSingleton<IAnsiConsole>(AnsiConsole.Console);
 builder.Services.AddSingleton<IChatConsole, ChatConsole>();
 builder.Services.AddSingleton<IChatController, ChatController>();
 


### PR DESCRIPTION
## Summary
- inject `IAnsiConsole` into `ChatConsole`
- register console instance in `Program`
- split streaming updates into helper methods
- update tests for new injection
- expand test coverage for error output and tool name formatting
- fix MCP server path resolution so relative paths work regardless of launch directory

## Testing
- `dotnet restore ConsoleChat.sln`
- `dotnet build ConsoleChat.sln`
- `dotnet test ConsoleChat.sln -v minimal`


------
https://chatgpt.com/codex/tasks/task_e_6855d5be61e483309f02332be655ffd2