### PR TITLE
Fix nullable warning in ChatConsole

### DIFF
--- a/SemanticKernelChat/Console/ChatConsole.cs
+++ b/SemanticKernelChat/Console/ChatConsole.cs
@@ -191,7 +191,7 @@ public class ChatConsole : IChatConsole
         {
             _ = paragraph.Append("\n");
             string toolName = update.AuthorName ?? update.Role.ToString();
-            var id = result.CallId;
+            string? id = result.CallId;
             if (!string.IsNullOrEmpty(id) && callNames.TryGetValue(id, out var nameFound))
             {
                 toolName = nameFound;


### PR DESCRIPTION
## Summary
- fix variable type for CallId in ChatConsole

## Testing
- `dotnet build ConsoleChat.sln`
- `dotnet test ConsoleChat.sln -v minimal`


------
https://chatgpt.com/codex/tasks/task_e_685612e06c58833088ef99a291c26aa3