### PR TITLE
Resolve MCP server command path relative to base directory

### DIFF
--- a/ConsoleChat.Tests/McpIntegrationTests.cs
+++ b/ConsoleChat.Tests/McpIntegrationTests.cs
@@ -33,4 +33,23 @@ public class McpIntegrationTests
             }
         }
     }
+
+    [Fact]
+    public async Task Tools_Are_Exposed_From_McpServer_From_Arbitrary_Cwd()
+    {
+        var original = Environment.CurrentDirectory;
+        var tempDir = Directory.CreateTempSubdirectory();
+        Environment.CurrentDirectory = tempDir.FullName;
+
+        try
+        {
+            await using var toolCollection = await McpToolCollection.CreateAsync();
+            Assert.True(toolCollection.Tools.Count >= 5);
+        }
+        finally
+        {
+            Environment.CurrentDirectory = original;
+            tempDir.Delete(recursive: true);
+        }
+    }
 }

--- a/SemanticKernelChat/Helpers/McpClientHelper.cs
+++ b/SemanticKernelChat/Helpers/McpClientHelper.cs
@@ -58,10 +58,19 @@ public static class McpClientHelper
             switch (transportType.ToLowerInvariant())
             {
                 case McpServerTypes.Stdio:
+                    string command = serverConfig.Command;
+                    if (!Path.IsPathFullyQualified(command) &&
+                        (command.Contains(Path.DirectorySeparatorChar) ||
+                         command.Contains(Path.AltDirectorySeparatorChar) ||
+                         Path.HasExtension(command)))
+                    {
+                        command = Path.GetFullPath(command, AppContext.BaseDirectory);
+                    }
+
                     yield return new StdioClientTransport(new()
                     {
                         Name = serverName,
-                        Command = serverConfig.Command,
+                        Command = command,
                         Arguments = serverConfig.Arguments,
                         EnvironmentVariables = serverConfig.EnvironmentVariables,
                         WorkingDirectory = AppContext.BaseDirectory,


### PR DESCRIPTION
## Summary
- resolve relative command paths when starting MCP server with more robust logic
- ensure client works when launched from any directory
- add regression test for launching server from arbitrary CWD

## Testing
- `dotnet build ConsoleChat.sln`
- `dotnet test ConsoleChat.sln -v minimal`
- `dotnet run --project SemanticKernelChat text-completion-test` (from repo root and from /tmp)


------
https://chatgpt.com/codex/tasks/task_e_685643e049cc83309066609d5d98c89e