### PR TITLE
Refactor tool naming logic

### DIFF
--- a/ConsoleChat.Tests/ChatConsoleTests.cs
+++ b/ConsoleChat.Tests/ChatConsoleTests.cs
@@ -166,7 +166,7 @@ public class ChatConsoleTests
         var console = new ChatConsole(new ChatLineEditor(new McpToolCollection()), testConsole);
         _ = await console.DisplayStreamingUpdatesAsync(updates);
 
-        Assert.Contains("tool Result", testConsole.Output);
+        Assert.Contains("Tool Result", testConsole.Output);
     }
 
     private static async IAsyncEnumerable<ChatResponseUpdate> AsAsyncEnumerable(IEnumerable<ChatResponseUpdate> updates)


### PR DESCRIPTION
## Summary
- deduplicate tool name calculation in `ChatConsole` via `GetToolName` helper
- update streaming result test for new default casing

## Testing
- `dotnet restore ConsoleChat.sln`
- `dotnet build ConsoleChat.sln`
- `dotnet test ConsoleChat.sln -v minimal`
- `dotnet run --project SemanticKernelChat text-completion-test`

------
https://chatgpt.com/codex/tasks/task_e_685660a182f4833080eb4d9a80165064