### PR TITLE
Add MCP prompt collection and shared server state

### DIFF
--- a/ConsoleChat.Tests/ChatCommandTests.cs
+++ b/ConsoleChat.Tests/ChatCommandTests.cs
@@ -42,7 +42,7 @@ public class ChatCommandTests
         var lineEditor = new FakeLineEditor(new[] { "hi", null });
         var chatConsole = new ChatConsole(lineEditor, testConsole);
         var client = new FakeChatClient { Response = new(new ChatMessage(ChatRole.Assistant, "done")) };
-        var controller = new ChatController(chatConsole, client, new McpToolCollection());
+        var controller = new ChatController(chatConsole, client, McpCollectionFactory.CreateToolCollection());
         var history = new ChatHistoryService();
         var command = new ChatCommand(history, controller, chatConsole, Enumerable.Empty<IChatCommandStrategy>());
 

--- a/ConsoleChat.Tests/ChatConsoleTests.cs
+++ b/ConsoleChat.Tests/ChatConsoleTests.cs
@@ -49,7 +49,7 @@ public class ChatConsoleTests
         var testConsole = new TestConsole();
 
         var msg = new ChatMessage(ChatRole.User, "hello");
-        var console = new ChatConsole(new ChatLineEditor(new McpToolCollection(), Enumerable.Empty<IChatCommandStrategy>()), testConsole);
+        var console = new ChatConsole(new ChatLineEditor(McpCollectionFactory.CreateToolCollection(), Enumerable.Empty<IChatCommandStrategy>()), testConsole);
         console.WriteChatMessages(msg);
 
         Assert.Empty(history.Messages);
@@ -71,7 +71,7 @@ public class ChatConsoleTests
             new FunctionResultContent("1", "r1")
         });
 
-        var console = new ChatConsole(new ChatLineEditor(new McpToolCollection(), Enumerable.Empty<IChatCommandStrategy>()), testConsole);
+        var console = new ChatConsole(new ChatLineEditor(McpCollectionFactory.CreateToolCollection(), Enumerable.Empty<IChatCommandStrategy>()), testConsole);
         console.WriteChatMessages(callMessage, resultMessage);
 
         Assert.Contains("First", testConsole.Output);
@@ -86,8 +86,8 @@ public class ChatConsoleTests
         var testConsole = new TestConsole();
 
         var client = new FakeChatClient { Response = new(new ChatMessage(ChatRole.Assistant, "done")) };
-        var console = new ChatConsole(new ChatLineEditor(new McpToolCollection(), Enumerable.Empty<IChatCommandStrategy>()), testConsole);
-        var controller = new ChatController(console, client, new McpToolCollection());
+        var console = new ChatConsole(new ChatLineEditor(McpCollectionFactory.CreateToolCollection(), Enumerable.Empty<IChatCommandStrategy>()), testConsole);
+        var controller = new ChatController(console, client, McpCollectionFactory.CreateToolCollection());
         await controller.SendAndDisplayAsync(history);
 
         Assert.Equal(2, history.Messages.Count);
@@ -106,8 +106,8 @@ public class ChatConsoleTests
         client.StreamingUpdates.Add(new ChatResponseUpdate(ChatRole.Assistant, "A"));
         client.StreamingUpdates.Add(new ChatResponseUpdate(ChatRole.Assistant, "B"));
 
-        var console = new ChatConsole(new ChatLineEditor(new McpToolCollection(), Enumerable.Empty<IChatCommandStrategy>()), testConsole);
-        var controller = new ChatController(console, client, new McpToolCollection());
+        var console = new ChatConsole(new ChatLineEditor(McpCollectionFactory.CreateToolCollection(), Enumerable.Empty<IChatCommandStrategy>()), testConsole);
+        var controller = new ChatController(console, client, McpCollectionFactory.CreateToolCollection());
         await controller.SendAndDisplayStreamingAsync(history);
 
         Assert.Equal(2, history.Messages.Count);
@@ -137,7 +137,7 @@ public class ChatConsoleTests
             new ChatResponseUpdate(ChatRole.Tool, resultContents)
         ]);
 
-        var console = new ChatConsole(new ChatLineEditor(new McpToolCollection(), Enumerable.Empty<IChatCommandStrategy>()), testConsole);
+        var console = new ChatConsole(new ChatLineEditor(McpCollectionFactory.CreateToolCollection(), Enumerable.Empty<IChatCommandStrategy>()), testConsole);
         _ = await console.DisplayStreamingUpdatesAsync(updates);
 
         Assert.Contains("First", testConsole.Output);
@@ -148,7 +148,7 @@ public class ChatConsoleTests
     public void DisplayError_Writes_Exception_Message()
     {
         var testConsole = new TestConsole();
-        var console = new ChatConsole(new ChatLineEditor(new McpToolCollection(), Enumerable.Empty<IChatCommandStrategy>()), testConsole);
+        var console = new ChatConsole(new ChatLineEditor(McpCollectionFactory.CreateToolCollection(), Enumerable.Empty<IChatCommandStrategy>()), testConsole);
 
         console.DisplayError(new InvalidOperationException("fail"));
 
@@ -164,7 +164,7 @@ public class ChatConsoleTests
             new ChatResponseUpdate(ChatRole.Tool, new[] { new FunctionResultContent("id", "r") })
         ]);
 
-        var console = new ChatConsole(new ChatLineEditor(new McpToolCollection(), Enumerable.Empty<IChatCommandStrategy>()), testConsole);
+        var console = new ChatConsole(new ChatLineEditor(McpCollectionFactory.CreateToolCollection(), Enumerable.Empty<IChatCommandStrategy>()), testConsole);
         _ = await console.DisplayStreamingUpdatesAsync(updates);
 
         Assert.Contains("Tool Result", testConsole.Output);

--- a/ConsoleChat.Tests/ChatControllerTests.cs
+++ b/ConsoleChat.Tests/ChatControllerTests.cs
@@ -22,7 +22,7 @@ public class ChatControllerTests
             .Returns(call => ((Func<Task>)call[0])());
 
         var client = new FakeChatClient { Response = new(new ChatMessage(ChatRole.Assistant, "done")) };
-        var controller = new ChatController(console, client, new McpToolCollection());
+        var controller = new ChatController(console, client, McpCollectionFactory.CreateToolCollection());
 
         await controller.SendAndDisplayAsync(history);
 
@@ -47,7 +47,7 @@ public class ChatControllerTests
             .GetResponseAsync(Arg.Any<IEnumerable<ChatMessage>>(), Arg.Any<ChatOptions?>(), Arg.Any<CancellationToken>())
             .Returns(call => Task.FromException<ChatResponse>(new InvalidOperationException("fail")));
 
-        var controller = new ChatController(console, client, new McpToolCollection());
+        var controller = new ChatController(console, client, McpCollectionFactory.CreateToolCollection());
 
         await controller.SendAndDisplayAsync(history);
 
@@ -71,7 +71,7 @@ public class ChatControllerTests
         console.DisplayStreamingUpdatesAsync(Arg.Any<IAsyncEnumerable<ChatResponseUpdate>>())
             .Returns(Task.FromResult<IReadOnlyList<ChatMessage>>(new[] { new ChatMessage(ChatRole.Assistant, "AB") }));
 
-        var controller = new ChatController(console, client, new McpToolCollection());
+        var controller = new ChatController(console, client, McpCollectionFactory.CreateToolCollection());
         IReadOnlyList<ChatMessage>? finalMessages = null;
 
         await controller.SendAndDisplayStreamingAsync(history, msgs => finalMessages = msgs);
@@ -97,7 +97,7 @@ public class ChatControllerTests
             .DisplayStreamingUpdatesAsync(Arg.Any<IAsyncEnumerable<ChatResponseUpdate>>())
             .Returns(call => Task.FromException<IReadOnlyList<ChatMessage>>(new InvalidOperationException("fail")));
 
-        var controller = new ChatController(console, client, new McpToolCollection());
+        var controller = new ChatController(console, client, McpCollectionFactory.CreateToolCollection());
 
         await controller.SendAndDisplayStreamingAsync(history);
 

--- a/ConsoleChat.Tests/SetMcpServerStateCommandStrategyTests.cs
+++ b/ConsoleChat.Tests/SetMcpServerStateCommandStrategyTests.cs
@@ -29,7 +29,8 @@ public class SetMcpServerStateCommandStrategyTests
             dict[name] = entry;
         }
 
-        var ctor = collectionType.GetConstructors(BindingFlags.NonPublic | BindingFlags.Instance)[0];
+        var ctor = collectionType.GetConstructor(BindingFlags.NonPublic | BindingFlags.Instance,
+            binder: null, types: new[] { stateType }, modifiers: null)!;
         var collection = (McpToolCollection)ctor.Invoke(new[] { state });
         return collection;
     }

--- a/ConsoleChat.Tests/TestUtilities/McpCollectionFactory.cs
+++ b/ConsoleChat.Tests/TestUtilities/McpCollectionFactory.cs
@@ -1,0 +1,9 @@
+using SemanticKernelChat.Infrastructure;
+
+namespace ConsoleChat.Tests.TestUtilities;
+
+internal static class McpCollectionFactory
+{
+    public static McpToolCollection CreateToolCollection()
+        => (McpToolCollection)Activator.CreateInstance(typeof(McpToolCollection), nonPublic: true)!;
+}

--- a/SemanticKernelChat/Infrastructure/McpPromptCollection.cs
+++ b/SemanticKernelChat/Infrastructure/McpPromptCollection.cs
@@ -9,7 +9,7 @@ public sealed class McpPromptCollection : IAsyncDisposable
 {
     private readonly McpServerState _state;
 
-    public McpPromptCollection()
+    private McpPromptCollection()
     {
         _state = (McpServerState)Activator.CreateInstance(typeof(McpServerState), nonPublic: true)!;
     }

--- a/SemanticKernelChat/Infrastructure/McpServerState.cs
+++ b/SemanticKernelChat/Infrastructure/McpServerState.cs
@@ -103,7 +103,7 @@ internal sealed class McpServerState : IAsyncDisposable
         }
     }
 
-    public static Task<McpServerState> CreateAsync(CancellationToken cancellationToken = default)
+    public static async Task<McpServerState> CreateAsync(CancellationToken cancellationToken = default)
     {
         var state = new McpServerState();
         var configuration = new ConfigurationBuilder()
@@ -123,7 +123,8 @@ internal sealed class McpServerState : IAsyncDisposable
             }
         }
 
-        return Task.FromResult(state);
+        await Task.WhenAll(state._loadTasks.Values);
+        return state;
     }
 
     public async ValueTask DisposeAsync()

--- a/SemanticKernelChat/Infrastructure/McpToolCollection.cs
+++ b/SemanticKernelChat/Infrastructure/McpToolCollection.cs
@@ -9,7 +9,7 @@ public sealed class McpToolCollection : IAsyncDisposable
 {
     private readonly McpServerState _state;
 
-    public McpToolCollection()
+    private McpToolCollection()
     {
         _state = (McpServerState)Activator.CreateInstance(typeof(McpServerState), nonPublic: true)!;
     }


### PR DESCRIPTION
## Summary
- introduce `McpServerState` for shared server loading
- track server `ServerStatus`
- add `McpPromptCollection` to pull prompts from servers
- refactor `McpToolCollection` to rely on new state
- update tests for the new design

## Testing
- `dotnet build ConsoleChat.sln -v minimal`
- `dotnet test ConsoleChat.sln -v minimal`


------
https://chatgpt.com/codex/tasks/task_e_685af96e926483308c9f8ccb736bc10f