### PR TITLE
Improve selection prompt display

### DIFF
--- a/SemanticKernelChat/Console/ChatConsole.cs
+++ b/SemanticKernelChat/Console/ChatConsole.cs
@@ -166,9 +166,9 @@ public class ChatConsole : IChatConsole
         {
             var table = new Table().Border(TableBorder.Rounded).BorderColor(Color.Grey);
             table.AddColumn("[bold]Selected[/]");
-            foreach (var r in result)
+            foreach (var selection in result)
             {
-                table.AddRow($"[yellow]*[/] {r.Name.EscapeMarkup()}");
+                table.AddRow($"[yellow]*[/] {selection.Name.EscapeMarkup()}");
             }
             _console.Write(table);
         }
@@ -177,7 +177,7 @@ public class ChatConsole : IChatConsole
             _console.MarkupLine("[grey]No selections made.[/]");
         }
 
-        return result.Select(r => r.Name).ToList();
+        return result.Select(selection => selection.Name).ToList();
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary
- clear color markup for prompt converter
- clear console after selection and show chosen items in a table

## Testing
- `dotnet restore ConsoleChat.sln`
- `dotnet build ConsoleChat.sln`
- `dotnet test ConsoleChat.sln -v minimal`
- `dotnet run --project SemanticKernelChat text-completion-test`

------
https://chatgpt.com/codex/tasks/task_e_685afc4cb31883308e1bd26d59a69f03