### PR TITLE
Fix completion cycling

### DIFF
--- a/ConsoleChat.Tests/SetMcpServerStateCommandStrategyTests.cs
+++ b/ConsoleChat.Tests/SetMcpServerStateCommandStrategyTests.cs
@@ -39,7 +39,7 @@ public class SetMcpServerStateCommandStrategyTests
 
         Assert.NotNull(completions);
         Assert.Contains(Enable, completions!);
-        Assert.DoesNotContain(Disable, completions!);
+        Assert.Contains(Disable, completions!);
     }
 
     [Fact]
@@ -64,7 +64,7 @@ public class SetMcpServerStateCommandStrategyTests
 
         Assert.NotNull(completions);
         Assert.Contains("first", completions!);
-        Assert.DoesNotContain("second", completions!); // prefix 'f' should match only first
+        Assert.Contains("second", completions!);
     }
 
     [Fact]

--- a/SemanticKernelChat/Console/Strategies/SetMcpServerStateCommandStrategy.cs
+++ b/SemanticKernelChat/Console/Strategies/SetMcpServerStateCommandStrategy.cs
@@ -18,24 +18,20 @@ public sealed class SetMcpServerStateCommandStrategy : IChatCommandStrategy
         var tokens = (prefix + word).TrimStart().Split(' ', StringSplitOptions.TrimEntries);
         if (tokens.Length == 1)
         {
-            return new[] { CliConstants.Commands.Enable, CliConstants.Commands.Disable }
-                .Where(c => c.StartsWith(word, StringComparison.OrdinalIgnoreCase))
-                .ToList();
+            return new[] { CliConstants.Commands.Enable, CliConstants.Commands.Disable };
         }
         if (tokens.Length == 2 &&
             (tokens[0].Equals(CliConstants.Commands.Enable, StringComparison.OrdinalIgnoreCase) ||
              tokens[0].Equals(CliConstants.Commands.Disable, StringComparison.OrdinalIgnoreCase)))
         {
-            return CliConstants.Options.Mcp.StartsWith(word, StringComparison.OrdinalIgnoreCase)
-                ? new[] { CliConstants.Options.Mcp }
-                : Array.Empty<string>();
+            return new[] { CliConstants.Options.Mcp };
         }
         if (tokens.Length >= 3 &&
             (tokens[0].Equals(CliConstants.Commands.Enable, StringComparison.OrdinalIgnoreCase) ||
              tokens[0].Equals(CliConstants.Commands.Disable, StringComparison.OrdinalIgnoreCase)) &&
             tokens[1].Equals(CliConstants.Options.Mcp, StringComparison.OrdinalIgnoreCase))
         {
-            return _tools.Servers.Where(n => n.StartsWith(word, StringComparison.OrdinalIgnoreCase)).ToList();
+            return _tools.Servers.ToList();
         }
         return null;
     }

--- a/SemanticKernelChat/Console/Strategies/ToggleMcpServerCommandStrategy.cs
+++ b/SemanticKernelChat/Console/Strategies/ToggleMcpServerCommandStrategy.cs
@@ -18,15 +18,11 @@ public sealed class ToggleMcpServerCommandStrategy : IChatCommandStrategy
         var tokens = (prefix + word).TrimStart().Split(' ', StringSplitOptions.TrimEntries);
         if (tokens.Length == 1)
         {
-            return CliConstants.Commands.Toggle.StartsWith(word, StringComparison.OrdinalIgnoreCase)
-                ? new[] { CliConstants.Commands.Toggle }
-                : null;
+            return new[] { CliConstants.Commands.Toggle };
         }
         if (tokens.Length == 2 && tokens[0].Equals(CliConstants.Commands.Toggle, StringComparison.OrdinalIgnoreCase))
         {
-            return CliConstants.Options.Mcp.StartsWith(word, StringComparison.OrdinalIgnoreCase)
-                ? new[] { CliConstants.Options.Mcp }
-                : Array.Empty<string>();
+            return new[] { CliConstants.Options.Mcp };
         }
         return null;
     }


### PR DESCRIPTION
## Summary
- avoid filtering completions by current word
- update unit tests for new behavior

## Testing
- `dotnet restore ConsoleChat.sln`
- `dotnet build ConsoleChat.sln`
- `dotnet test ConsoleChat.sln -v minimal`
- `dotnet run --project SemanticKernelChat text-completion-test`


------
https://chatgpt.com/codex/tasks/task_e_685b02282390833082c2edf0733dc6e0