### PR TITLE
Use expression-bodied CreateCollection methods

### DIFF
--- a/ConsoleChat.Tests/ListPromptsCommandStrategyTests.cs
+++ b/ConsoleChat.Tests/ListPromptsCommandStrategyTests.cs
@@ -9,10 +9,8 @@ public class ListPromptsCommandStrategyTests
     private const string List = "/list";
     private const string Prompts = "prompts";
 
-    private static McpPromptCollection CreateCollection()
-    {
-        return McpCollectionFactory.CreatePromptCollection();
-    }
+    private static McpPromptCollection CreateCollection() =>
+        McpCollectionFactory.CreatePromptCollection();
 
     [Fact]
     public void GetCompletions_Returns_Command_Name()

--- a/ConsoleChat.Tests/ListToolsCommandStrategyTests.cs
+++ b/ConsoleChat.Tests/ListToolsCommandStrategyTests.cs
@@ -9,10 +9,8 @@ public class ListToolsCommandStrategyTests
     private const string List = "/list";
     private const string Tools = "tools";
 
-    private static McpToolCollection CreateCollection()
-    {
-        return McpCollectionFactory.CreateToolCollection();
-    }
+    private static McpToolCollection CreateCollection() =>
+        McpCollectionFactory.CreateToolCollection();
 
     [Fact]
     public void GetCompletions_Returns_Command_Name()


### PR DESCRIPTION
## Summary
- refactor `CreateCollection` methods in test classes to expression-bodied members

## Testing
- `dotnet restore ConsoleChat.sln`
- `dotnet build ConsoleChat.sln`
- `dotnet test ConsoleChat.sln -v minimal`


------
https://chatgpt.com/codex/tasks/task_e_685de1501fdc83308d25fb5036270497