### PR TITLE
Rename EchoTool class to EchoTools

### DIFF
--- a/ConsoleChat.Tests/McpFunctionTests.cs
+++ b/ConsoleChat.Tests/McpFunctionTests.cs
@@ -27,14 +27,14 @@ public class McpFunctionTests
     [Fact]
     public void Echo_Returns_Prefixed_Message()
     {
-        string result = EchoTool.Echo("test");
+        string result = EchoTools.Echo("test");
         Assert.Equal("Hello from C#: test", result);
     }
 
     [Fact]
     public void ReverseEcho_Returns_Reversed_Message()
     {
-        string result = EchoTool.ReverseEcho("abc");
+        string result = EchoTools.ReverseEcho("abc");
         Assert.Equal("cba", result);
     }
 }

--- a/McpServer/EchoTools.cs
+++ b/McpServer/EchoTools.cs
@@ -3,7 +3,7 @@ using ModelContextProtocol.Server;
 using System.ComponentModel;
 
 [McpServerToolType]
-public static class EchoTool
+public static class EchoTools
 {
     [McpServerTool, Description("Echoes the message back to the client.")]
     public static string Echo(string message) => $"Hello from C#: {message}";


### PR DESCRIPTION
## Summary
- rename EchoTool class to EchoTools
- update McpFunctionTests to use EchoTools

## Testing
- `dotnet restore ConsoleChat.sln`
- `dotnet build ConsoleChat.sln`
- `dotnet test ConsoleChat.sln -v minimal`


------
https://chatgpt.com/codex/tasks/task_e_686b42d169f88330ac2c0c3da7d9b1f5