### PR TITLE
Add namespace for MCP tool classes

### DIFF
--- a/ConsoleChat.Tests/McpFunctionTests.cs
+++ b/ConsoleChat.Tests/McpFunctionTests.cs
@@ -1,3 +1,5 @@
+using McpServer;
+
 namespace ConsoleChat.Tests;
 
 public class McpFunctionTests

--- a/McpServer/AdditionalTools.cs
+++ b/McpServer/AdditionalTools.cs
@@ -1,6 +1,8 @@
 using ModelContextProtocol.Server;
 using System.ComponentModel;
 
+namespace McpServer;
+
 [McpServerToolType]
 public static class UtilityTools
 {

--- a/McpServer/EchoTools.cs
+++ b/McpServer/EchoTools.cs
@@ -2,6 +2,8 @@ using ModelContextProtocol.Server;
 
 using System.ComponentModel;
 
+namespace McpServer;
+
 [McpServerToolType]
 public static class EchoTools
 {


### PR DESCRIPTION
## Summary
- add file-scoped namespace `McpServer` for `UtilityTools` and `EchoTools`
- update tests to reference tools via `using McpServer`

## Testing
- `dotnet restore ConsoleChat.sln`
- `dotnet test ConsoleChat.sln -v minimal`


------
https://chatgpt.com/codex/tasks/task_e_686b5be5e2088330b7fae319c93ff8bb