### PR TITLE
Unify root namespace to RaindropServer

### DIFF
--- a/RaindropServer.Tests/CollectionsTests.cs
+++ b/RaindropServer.Tests/CollectionsTests.cs
@@ -1,8 +1,8 @@
-using RaindropTools.Collections;
-using RaindropTools.Common;
+using RaindropServer.Collections;
+using RaindropServer.Common;
 using Microsoft.Extensions.DependencyInjection;
 
-namespace RaindropTools.Tests;
+namespace RaindropServer.Tests;
 
 public class CollectionsTests : TestBase
 {

--- a/RaindropServer.Tests/HighlightsTests.cs
+++ b/RaindropServer.Tests/HighlightsTests.cs
@@ -1,10 +1,10 @@
-using RaindropTools.Collections;
-using RaindropTools.Raindrops;
-using RaindropTools.Highlights;
+using RaindropServer.Collections;
+using RaindropServer.Raindrops;
+using RaindropServer.Highlights;
 using Microsoft.Extensions.DependencyInjection;
 using System.Linq;
 
-namespace RaindropTools.Tests;
+namespace RaindropServer.Tests;
 
 public class HighlightsTests : TestBase
 {

--- a/RaindropServer.Tests/IntegrationTests.cs
+++ b/RaindropServer.Tests/IntegrationTests.cs
@@ -1,11 +1,11 @@
-using RaindropTools.Collections;
-using RaindropTools.Raindrops;
-using RaindropTools.Highlights;
-using RaindropTools.Tags;
-using RaindropTools.Common;
+using RaindropServer.Collections;
+using RaindropServer.Raindrops;
+using RaindropServer.Highlights;
+using RaindropServer.Tags;
+using RaindropServer.Common;
 using Microsoft.Extensions.DependencyInjection;
 
-namespace RaindropTools.Tests;
+namespace RaindropServer.Tests;
 
 public class IntegrationTests : TestBase
 {

--- a/RaindropServer.Tests/RaindropsBulkTests.cs
+++ b/RaindropServer.Tests/RaindropsBulkTests.cs
@@ -1,9 +1,9 @@
 using Microsoft.Extensions.DependencyInjection;
-using RaindropTools.Raindrops;
+using RaindropServer.Raindrops;
 using System.Linq;
 using System.Collections.Generic;
 
-namespace RaindropTools.Tests;
+namespace RaindropServer.Tests;
 
 public class RaindropsBulkTests : TestBase
 {

--- a/RaindropServer.Tests/RaindropsTests.cs
+++ b/RaindropServer.Tests/RaindropsTests.cs
@@ -1,7 +1,7 @@
-using RaindropTools.Raindrops;
+using RaindropServer.Raindrops;
 using Microsoft.Extensions.DependencyInjection;
 
-namespace RaindropTools.Tests;
+namespace RaindropServer.Tests;
 
 public class RaindropsTests : TestBase
 {

--- a/RaindropServer.Tests/TagsTests.cs
+++ b/RaindropServer.Tests/TagsTests.cs
@@ -1,8 +1,8 @@
-using RaindropTools.Raindrops;
-using RaindropTools.Tags;
+using RaindropServer.Raindrops;
+using RaindropServer.Tags;
 using Microsoft.Extensions.DependencyInjection;
 
-namespace RaindropTools.Tests;
+namespace RaindropServer.Tests;
 
 public class TagsTests : TestBase
 {

--- a/RaindropServer.Tests/TestBase.cs
+++ b/RaindropServer.Tests/TestBase.cs
@@ -1,7 +1,7 @@
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 
-namespace RaindropTools.Tests;
+namespace RaindropServer.Tests;
 
 public abstract class TestBase
 {

--- a/RaindropServer/Collections/Collection.cs
+++ b/RaindropServer/Collections/Collection.cs
@@ -1,7 +1,7 @@
 using System.Text.Json.Serialization;
-using RaindropTools.Common;
+using RaindropServer.Common;
 
-namespace RaindropTools.Collections;
+namespace RaindropServer.Collections;
 
 public class Collection
 {

--- a/RaindropServer/Collections/CollectionsTools.cs
+++ b/RaindropServer/Collections/CollectionsTools.cs
@@ -1,8 +1,8 @@
 using System.ComponentModel;
 using ModelContextProtocol.Server;
-using RaindropTools.Common;
+using RaindropServer.Common;
 
-namespace RaindropTools.Collections;
+namespace RaindropServer.Collections;
 
 [McpServerToolType]
 public class CollectionsTools

--- a/RaindropServer/Collections/ICollectionsApi.cs
+++ b/RaindropServer/Collections/ICollectionsApi.cs
@@ -1,7 +1,7 @@
 using Refit;
-using RaindropTools.Common;
+using RaindropServer.Common;
 
-namespace RaindropTools.Collections;
+namespace RaindropServer.Collections;
 
 public interface ICollectionsApi
 {

--- a/RaindropServer/Common/ApiResponses.cs
+++ b/RaindropServer/Common/ApiResponses.cs
@@ -1,4 +1,4 @@
-namespace RaindropTools.Common;
+namespace RaindropServer.Common;
 
 public record ItemResponse<T>(bool Result, T Item);
 

--- a/RaindropServer/Common/IdRef.cs
+++ b/RaindropServer/Common/IdRef.cs
@@ -1,6 +1,6 @@
 using System.Text.Json.Serialization;
 
-namespace RaindropTools.Common;
+namespace RaindropServer.Common;
 
 public class IdRef
 {

--- a/RaindropServer/Highlights/Highlight.cs
+++ b/RaindropServer/Highlights/Highlight.cs
@@ -1,6 +1,6 @@
 using System.Text.Json.Serialization;
 
-namespace RaindropTools.Highlights;
+namespace RaindropServer.Highlights;
 
 public class Highlight
 {

--- a/RaindropServer/Highlights/HighlightsBulkUpdate.cs
+++ b/RaindropServer/Highlights/HighlightsBulkUpdate.cs
@@ -1,6 +1,6 @@
 using System.Text.Json.Serialization;
 
-namespace RaindropTools.Highlights;
+namespace RaindropServer.Highlights;
 
 public class HighlightsBulkUpdate
 {

--- a/RaindropServer/Highlights/HighlightsBulkUpdateRequest.cs
+++ b/RaindropServer/Highlights/HighlightsBulkUpdateRequest.cs
@@ -1,4 +1,4 @@
-namespace RaindropTools.Highlights;
+namespace RaindropServer.Highlights;
 
 public class HighlightsBulkUpdateRequest
 {

--- a/RaindropServer/Highlights/HighlightsTools.cs
+++ b/RaindropServer/Highlights/HighlightsTools.cs
@@ -1,8 +1,8 @@
 using System.ComponentModel;
 using ModelContextProtocol.Server;
-using RaindropTools.Common;
+using RaindropServer.Common;
 
-namespace RaindropTools.Highlights;
+namespace RaindropServer.Highlights;
 
 [McpServerToolType]
 public class HighlightsTools

--- a/RaindropServer/Highlights/IHighlightsApi.cs
+++ b/RaindropServer/Highlights/IHighlightsApi.cs
@@ -1,7 +1,7 @@
 using Refit;
-using RaindropTools.Common;
+using RaindropServer.Common;
 
-namespace RaindropTools.Highlights;
+namespace RaindropServer.Highlights;
 
 public interface IHighlightsApi
 {

--- a/RaindropServer/Highlights/RaindropHighlights.cs
+++ b/RaindropServer/Highlights/RaindropHighlights.cs
@@ -1,6 +1,6 @@
 using System.Text.Json.Serialization;
 
-namespace RaindropTools.Highlights;
+namespace RaindropServer.Highlights;
 
 public class RaindropHighlights
 {

--- a/RaindropServer/Program.cs
+++ b/RaindropServer/Program.cs
@@ -1,4 +1,4 @@
-using RaindropTools;
+using RaindropServer;
 
 var builder = Host.CreateApplicationBuilder(args);
 

--- a/RaindropServer/RaindropOptions.cs
+++ b/RaindropServer/RaindropOptions.cs
@@ -1,4 +1,4 @@
-namespace RaindropTools;
+namespace RaindropServer;
 
 /// <summary>
 /// Options for configuring the Raindrop API client.

--- a/RaindropServer/RaindropServer.csproj
+++ b/RaindropServer/RaindropServer.csproj
@@ -3,6 +3,7 @@
     <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
+    <RootNamespace>RaindropServer</RootNamespace>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.1" />

--- a/RaindropServer/RaindropServiceCollectionExtensions.cs
+++ b/RaindropServer/RaindropServiceCollectionExtensions.cs
@@ -3,13 +3,13 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 using Refit;
 using System.Net.Http.Headers;
-using RaindropTools.Collections;
-using RaindropTools.Raindrops;
-using RaindropTools.Highlights;
-using RaindropTools.Tags;
-using RaindropTools.User;
+using RaindropServer.Collections;
+using RaindropServer.Raindrops;
+using RaindropServer.Highlights;
+using RaindropServer.Tags;
+using RaindropServer.User;
 
-namespace RaindropTools;
+namespace RaindropServer;
 
 /// <summary>
 /// Extension methods for registering Raindrop API services.

--- a/RaindropServer/Raindrops/IRaindropsApi.cs
+++ b/RaindropServer/Raindrops/IRaindropsApi.cs
@@ -1,7 +1,7 @@
 using Refit;
-using RaindropTools.Common;
+using RaindropServer.Common;
 
-namespace RaindropTools.Raindrops;
+namespace RaindropServer.Raindrops;
 
 public interface IRaindropsApi
 {

--- a/RaindropServer/Raindrops/Raindrop.cs
+++ b/RaindropServer/Raindrops/Raindrop.cs
@@ -1,7 +1,7 @@
 using System.Text.Json.Serialization;
-using RaindropTools.Common;
+using RaindropServer.Common;
 
-namespace RaindropTools.Raindrops;
+namespace RaindropServer.Raindrops;
 
 public class Raindrop
 {

--- a/RaindropServer/Raindrops/RaindropsBulkUpdate.cs
+++ b/RaindropServer/Raindrops/RaindropsBulkUpdate.cs
@@ -1,7 +1,7 @@
 using System.Text.Json.Serialization;
-using RaindropTools.Common;
+using RaindropServer.Common;
 
-namespace RaindropTools.Raindrops;
+namespace RaindropServer.Raindrops;
 
 public class RaindropsBulkUpdate
 {

--- a/RaindropServer/Raindrops/RaindropsCreateMany.cs
+++ b/RaindropServer/Raindrops/RaindropsCreateMany.cs
@@ -1,6 +1,6 @@
 using System.Text.Json.Serialization;
 
-namespace RaindropTools.Raindrops;
+namespace RaindropServer.Raindrops;
 
 public class RaindropsCreateMany
 {

--- a/RaindropServer/Raindrops/RaindropsTools.cs
+++ b/RaindropServer/Raindrops/RaindropsTools.cs
@@ -1,9 +1,9 @@
 using System.ComponentModel;
 using System.Linq;
 using ModelContextProtocol.Server;
-using RaindropTools.Common;
+using RaindropServer.Common;
 
-namespace RaindropTools.Raindrops;
+namespace RaindropServer.Raindrops;
 
 [McpServerToolType]
 public class RaindropsTools

--- a/RaindropServer/Tags/ITagsApi.cs
+++ b/RaindropServer/Tags/ITagsApi.cs
@@ -1,7 +1,7 @@
 using Refit;
-using RaindropTools.Common;
+using RaindropServer.Common;
 
-namespace RaindropTools.Tags;
+namespace RaindropServer.Tags;
 
 public interface ITagsApi
 {

--- a/RaindropServer/Tags/TagInfo.cs
+++ b/RaindropServer/Tags/TagInfo.cs
@@ -1,6 +1,6 @@
 using System.Text.Json.Serialization;
 
-namespace RaindropTools.Tags;
+namespace RaindropServer.Tags;
 
 public class TagInfo
 {

--- a/RaindropServer/Tags/TagsTools.cs
+++ b/RaindropServer/Tags/TagsTools.cs
@@ -1,8 +1,8 @@
 using System.ComponentModel;
 using ModelContextProtocol.Server;
-using RaindropTools.Common;
+using RaindropServer.Common;
 
-namespace RaindropTools.Tags;
+namespace RaindropServer.Tags;
 
 [McpServerToolType]
 public class TagsTools

--- a/RaindropServer/User/IUserApi.cs
+++ b/RaindropServer/User/IUserApi.cs
@@ -1,7 +1,7 @@
 using Refit;
-using RaindropTools.Common;
+using RaindropServer.Common;
 
-namespace RaindropTools.User;
+namespace RaindropServer.User;
 
 public interface IUserApi
 {

--- a/RaindropServer/User/UserInfo.cs
+++ b/RaindropServer/User/UserInfo.cs
@@ -1,6 +1,6 @@
 using System.Text.Json.Serialization;
 
-namespace RaindropTools.User;
+namespace RaindropServer.User;
 
 public class UserInfo
 {

--- a/RaindropServer/User/UserTools.cs
+++ b/RaindropServer/User/UserTools.cs
@@ -1,8 +1,8 @@
 using System.ComponentModel;
 using ModelContextProtocol.Server;
-using RaindropTools.Common;
+using RaindropServer.Common;
 
-namespace RaindropTools.User;
+namespace RaindropServer.User;
 
 [McpServerToolType]
 public class UserTools


### PR DESCRIPTION
## Summary
- set `<RootNamespace>` in `RaindropServer.csproj`
- rename namespaces from `RaindropTools` to `RaindropServer`
- update using statements and tests

## Testing
- `dotnet restore ConsoleChat.sln`
- `dotnet build ConsoleChat.sln`
- `dotnet test ConsoleChat.sln -v minimal`
- `dotnet run --project SemanticKernelChat text-completion-test`


------
https://chatgpt.com/codex/tasks/task_e_686b5c6bea0c833095488b979b595984