### PR TITLE
Parameterize renderable samples

### DIFF
--- a/SemanticKernelChat/Clients/EchoChatClient.cs
+++ b/SemanticKernelChat/Clients/EchoChatClient.cs
@@ -57,52 +57,50 @@ public sealed class EchoChatClient : IChatClient
                 yield return new ChatResponseUpdate(ChatRole.Assistant, c.ToString());
             }
 
-            var callContents = new List<AIContent>
+            var tableParams = new Dictionary<string, object?>
             {
-                new FunctionCallContent(
-                    "tool_call_table",
-                    "RenderableFunctions_SampleTable",
-                    new Dictionary<string, object?>
+                ["items"] = new[]
+                {
+                    new Dictionary<string, object?> { ["Name"] = "Apples", ["Count"] = 12 },
+                    new Dictionary<string, object?> { ["Name"] = "Bananas", ["Count"] = 7 }
+                }
+            };
+
+            var treeParams = new Dictionary<string, object?>
+            {
+                ["root"] = new Dictionary<string, object?>
+                {
+                    ["Name"] = "Root",
+                    ["Children"] = new[]
                     {
-                        ["items"] = new[]
+                        new Dictionary<string, object?>
                         {
-                            new Dictionary<string, object?> { ["Name"] = "Apples", ["Count"] = 12 },
-                            new Dictionary<string, object?> { ["Name"] = "Bananas", ["Count"] = 7 }
-                        }
-                    }),
-                new FunctionCallContent(
-                    "tool_call_tree",
-                    "RenderableFunctions_SampleTree",
-                    new Dictionary<string, object?>
-                    {
-                        ["root"] = new Dictionary<string, object?>
-                        {
-                            ["Name"] = "Root",
+                            ["Name"] = "Branch 1",
                             ["Children"] = new[]
                             {
-                                new Dictionary<string, object?>
-                                {
-                                    ["Name"] = "Branch 1",
-                                    ["Children"] = new[]
-                                    {
-                                        new Dictionary<string, object?> { ["Name"] = "Leaf" }
-                                    }
-                                },
-                                new Dictionary<string, object?> { ["Name"] = "Branch 2" }
+                                new Dictionary<string, object?> { ["Name"] = "Leaf" }
                             }
-                        }
-                    }),
-                new FunctionCallContent(
-                    "tool_call_chart",
-                    "RenderableFunctions_SampleChart",
-                    new Dictionary<string, object?>
-                    {
-                        ["items"] = new[]
-                        {
-                            new Dictionary<string, object?> { ["Name"] = "Apples", ["Value"] = 12, ["Color"] = "Red" },
-                            new Dictionary<string, object?> { ["Name"] = "Bananas", ["Value"] = 7, ["Color"] = "Yellow" }
-                        }
-                    })
+                        },
+                        new Dictionary<string, object?> { ["Name"] = "Branch 2" }
+                    }
+                }
+            };
+
+            var chartParams = new Dictionary<string, object?>
+            {
+                ["items"] = new[]
+                {
+                    new Dictionary<string, object?> { ["Name"] = "Apples", ["Value"] = 12, ["Color"] = "Red" },
+                    new Dictionary<string, object?> { ["Name"] = "Bananas", ["Value"] = 7, ["Color"] = "Yellow" }
+                },
+                ["title"] = "Fruit Sales"
+            };
+
+            var callContents = new List<AIContent>
+            {
+                new FunctionCallContent("tool_call_table", "RenderableFunctions_SampleTable", tableParams),
+                new FunctionCallContent("tool_call_tree", "RenderableFunctions_SampleTree", treeParams),
+                new FunctionCallContent("tool_call_chart", "RenderableFunctions_SampleChart", chartParams)
             };
 
             await Task.Delay(100, cancellationToken);

--- a/SemanticKernelChat/Commands/TextCompletionTestCommand.cs
+++ b/SemanticKernelChat/Commands/TextCompletionTestCommand.cs
@@ -81,18 +81,13 @@ public sealed class TextCompletionTestCommand : ChatCommandBase
             new RenderableFunctions.ItemCount("Bananas", 7)
         };
 
-        var treeData = new RenderableFunctions.TreeItem(
-            "Root",
-            new[]
-            {
-                new RenderableFunctions.TreeItem(
-                    "Branch 1",
-                    new[]
-                    {
-                        new RenderableFunctions.TreeItem("Leaf", null)
-                    }),
-                new RenderableFunctions.TreeItem("Branch 2", null)
-            });
+        var leaf = new RenderableFunctions.TreeNode("Leaf");
+        var branch1 = new RenderableFunctions.TreeNode("Branch 1");
+        branch1.AddChild(leaf);
+        var branch2 = new RenderableFunctions.TreeNode("Branch 2");
+        var treeData = new RenderableFunctions.TreeNode("Root");
+        treeData.AddChild(branch1);
+        treeData.AddChild(branch2);
 
         var chartData = new[]
         {
@@ -104,7 +99,7 @@ public sealed class TextCompletionTestCommand : ChatCommandBase
         {
             KernelFunctionFactory.CreateFromMethod(() => functions.SampleTable(tableData)),
             KernelFunctionFactory.CreateFromMethod(() => functions.SampleTree(treeData)),
-            KernelFunctionFactory.CreateFromMethod(() => functions.SampleChart(chartData))
+            KernelFunctionFactory.CreateFromMethod(() => functions.SampleChart(chartData, "Fruit Sales"))
         };
 
         var plugin = KernelPluginFactory.CreateFromFunctions("RenderableFunctions", kernelFunctions);


### PR DESCRIPTION
## Summary
- add ItemCount and ChartItem models
- parameterize RenderableFunctions with input data
- bind sample data in TextCompletionTestCommand
- send sample parameters from EchoChatClient
- make SampleTree recursive using TreeItem structure

## Testing
- `dotnet restore ConsoleChat.sln`
- `dotnet build ConsoleChat.sln`
- `dotnet test ConsoleChat.sln -v minimal`
- `dotnet run --project SemanticKernelChat text-completion-test`


------
https://chatgpt.com/codex/tasks/task_e_686b603065e48330a09f10c106de68da