### PR TITLE
Switch Raindrop models to records

### DIFF
--- a/RaindropServer/Collections/Collection.cs
+++ b/RaindropServer/Collections/Collection.cs
@@ -3,21 +3,21 @@ using RaindropServer.Common;
 
 namespace RaindropServer.Collections;
 
-public class Collection
+public record Collection
 {
     [JsonPropertyName("_id")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
-    public int Id { get; set; }
+    public int Id { get; init; }
 
-    public string? Title { get; set; }
+    public string? Title { get; init; }
 
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
-    public IdRef? Parent { get; set; }
+    public IdRef? Parent { get; init; }
 
-    public string? Color { get; set; }
+    public string? Color { get; init; }
 
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-    public List<string>? Cover { get; set; }
+    public List<string>? Cover { get; init; }
 
-    public bool? Public { get; set; }
+    public bool? Public { get; init; }
 }

--- a/RaindropServer/Common/IdRef.cs
+++ b/RaindropServer/Common/IdRef.cs
@@ -2,8 +2,8 @@ using System.Text.Json.Serialization;
 
 namespace RaindropServer.Common;
 
-public class IdRef
+public record IdRef
 {
     [JsonPropertyName("$id")]
-    public int Id { get; set; }
+    public int Id { get; init; }
 }

--- a/RaindropServer/Highlights/Highlight.cs
+++ b/RaindropServer/Highlights/Highlight.cs
@@ -2,26 +2,26 @@ using System.Text.Json.Serialization;
 
 namespace RaindropServer.Highlights;
 
-public class Highlight
+public record Highlight
 {
     [JsonPropertyName("_id")]
-    public string? Id { get; set; }
+    public string? Id { get; init; }
 
-    public string? Text { get; set; }
+    public string? Text { get; init; }
 
-    public string? Title { get; set; }
+    public string? Title { get; init; }
 
-    public string? Color { get; set; }
+    public string? Color { get; init; }
 
-    public string? Note { get; set; }
+    public string? Note { get; init; }
 
-    public string? Created { get; set; }
+    public string? Created { get; init; }
 
-    public List<string>? Tags { get; set; }
+    public List<string>? Tags { get; init; }
 
-    public string? Link { get; set; }
+    public string? Link { get; init; }
 
-    public string? LastUpdate { get; set; }
+    public string? LastUpdate { get; init; }
 
-    public long? RaindropRef { get; set; }
+    public long? RaindropRef { get; init; }
 }

--- a/RaindropServer/Highlights/HighlightsBulkUpdate.cs
+++ b/RaindropServer/Highlights/HighlightsBulkUpdate.cs
@@ -2,20 +2,20 @@ using System.Text.Json.Serialization;
 
 namespace RaindropServer.Highlights;
 
-public class HighlightsBulkUpdate
+public record HighlightsBulkUpdate
 {
     [JsonPropertyName("_id")]
-    public string? Id { get; set; }
+    public string? Id { get; init; }
 
-    public string? Text { get; set; }
+    public string? Text { get; init; }
 
-    public string? Note { get; set; }
+    public string? Note { get; init; }
 
-    public string? Color { get; set; }
-
-    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-    public string? Created { get; set; }
+    public string? Color { get; init; }
 
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-    public string? LastUpdate { get; set; }
+    public string? Created { get; init; }
+
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? LastUpdate { get; init; }
 }

--- a/RaindropServer/Highlights/HighlightsBulkUpdateRequest.cs
+++ b/RaindropServer/Highlights/HighlightsBulkUpdateRequest.cs
@@ -1,6 +1,6 @@
 namespace RaindropServer.Highlights;
 
-public class HighlightsBulkUpdateRequest
+public record HighlightsBulkUpdateRequest
 {
-    public List<HighlightsBulkUpdate> Highlights { get; set; } = new();
+    public List<HighlightsBulkUpdate> Highlights { get; init; } = new();
 }

--- a/RaindropServer/Highlights/RaindropHighlights.cs
+++ b/RaindropServer/Highlights/RaindropHighlights.cs
@@ -2,10 +2,10 @@ using System.Text.Json.Serialization;
 
 namespace RaindropServer.Highlights;
 
-public class RaindropHighlights
+public record RaindropHighlights
 {
     [JsonPropertyName("_id")]
-    public long? Id { get; set; }
+    public long? Id { get; init; }
 
-    public List<Highlight> Highlights { get; set; } = new();
+    public List<Highlight> Highlights { get; init; } = new();
 }

--- a/RaindropServer/Raindrops/Raindrop.cs
+++ b/RaindropServer/Raindrops/Raindrop.cs
@@ -3,28 +3,28 @@ using RaindropServer.Common;
 
 namespace RaindropServer.Raindrops;
 
-public class Raindrop
+public record Raindrop
 {
     [JsonPropertyName("_id")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
-    public long Id { get; set; }
+    public long Id { get; init; }
 
-    public string? Title { get; set; }
-
-    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-    public string? Link { get; set; }
+    public string? Title { get; init; }
 
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-    public string? Excerpt { get; set; }
+    public string? Link { get; init; }
 
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-    public List<string>? Tags { get; set; }
-
-    public bool? Important { get; set; }
+    public string? Excerpt { get; init; }
 
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-    public IdRef? Collection { get; set; }
+    public List<string>? Tags { get; init; }
+
+    public bool? Important { get; init; }
 
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-    public int? CollectionId { get; set; }
+    public IdRef? Collection { get; init; }
+
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public int? CollectionId { get; init; }
 }

--- a/RaindropServer/Raindrops/RaindropsBulkUpdate.cs
+++ b/RaindropServer/Raindrops/RaindropsBulkUpdate.cs
@@ -3,23 +3,23 @@ using RaindropServer.Common;
 
 namespace RaindropServer.Raindrops;
 
-public class RaindropsBulkUpdate
+public record RaindropsBulkUpdate
 {
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-    public List<long>? Ids { get; set; }
+    public List<long>? Ids { get; init; }
 
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-    public bool? Important { get; set; }
+    public bool? Important { get; init; }
 
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-    public List<string>? Tags { get; set; }
+    public List<string>? Tags { get; init; }
 
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-    public List<object>? Media { get; set; }
+    public List<object>? Media { get; init; }
 
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-    public string? Cover { get; set; }
+    public string? Cover { get; init; }
 
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-    public IdRef? Collection { get; set; }
+    public IdRef? Collection { get; init; }
 }

--- a/RaindropServer/Raindrops/RaindropsCreateMany.cs
+++ b/RaindropServer/Raindrops/RaindropsCreateMany.cs
@@ -2,10 +2,10 @@ using System.Text.Json.Serialization;
 
 namespace RaindropServer.Raindrops;
 
-public class RaindropsCreateMany
+public record RaindropsCreateMany
 {
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-    public int? CollectionId { get; set; }
+    public int? CollectionId { get; init; }
 
-    public List<Raindrop> Items { get; set; } = new();
+    public List<Raindrop> Items { get; init; } = new();
 }

--- a/RaindropServer/Tags/TagDeleteRequest.cs
+++ b/RaindropServer/Tags/TagDeleteRequest.cs
@@ -1,6 +1,6 @@
 namespace RaindropServer.Tags;
 
-public class TagDeleteRequest
+public record TagDeleteRequest
 {
     public List<string> Tags { get; init; } = new();
 }

--- a/RaindropServer/Tags/TagInfo.cs
+++ b/RaindropServer/Tags/TagInfo.cs
@@ -2,10 +2,10 @@ using System.Text.Json.Serialization;
 
 namespace RaindropServer.Tags;
 
-public class TagInfo
+public record TagInfo
 {
     [JsonPropertyName("_id")]
-    public string Id { get; set; } = string.Empty;
+    public string Id { get; init; } = string.Empty;
 
-    public int Count { get; set; }
+    public int Count { get; init; }
 }

--- a/RaindropServer/Tags/TagRenameRequest.cs
+++ b/RaindropServer/Tags/TagRenameRequest.cs
@@ -2,10 +2,10 @@ using System.Text.Json.Serialization;
 
 namespace RaindropServer.Tags;
 
-public class TagRenameRequest
+public record TagRenameRequest
 {
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-    public string? Replace { get; set; }
+    public string? Replace { get; init; }
 
     public List<string> Tags { get; init; } = new();
 }

--- a/RaindropServer/User/UserInfo.cs
+++ b/RaindropServer/User/UserInfo.cs
@@ -2,22 +2,22 @@ using System.Text.Json.Serialization;
 
 namespace RaindropServer.User;
 
-public class UserInfo
+public record UserInfo
 {
     [JsonPropertyName("_id")]
-    public int Id { get; set; }
+    public int Id { get; init; }
 
-    public string? Email { get; set; }
+    public string? Email { get; init; }
 
-    public string? FullName { get; set; }
+    public string? FullName { get; init; }
 
-    public bool Pro { get; set; }
+    public bool Pro { get; init; }
 
-    public object? Config { get; set; }
+    public object? Config { get; init; }
 
-    public object? Dropbox { get; set; }
+    public object? Dropbox { get; init; }
 
-    public object? Files { get; set; }
+    public object? Files { get; init; }
 
-    public string? Type { get; set; }
+    public string? Type { get; init; }
 }


### PR DESCRIPTION
## Summary
- convert POCO types in RaindropServer to `record`
- keep property initializers and serialization attributes intact

## Testing
- `dotnet test ConsoleChat.sln -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_686bcc22b6648330a546b4a21cae03e5