### PR TITLE
Check capabilities before listing tools

### DIFF
--- a/SemanticKernelChat/Infrastructure/McpServerManager.cs
+++ b/SemanticKernelChat/Infrastructure/McpServerManager.cs
@@ -97,17 +97,13 @@ public sealed class McpServerManager : IAsyncDisposable
 
             var capabilities = client.ServerCapabilities;
 
-            IList<McpClientTool> tools = Array.Empty<McpClientTool>();
-            if (capabilities.Tools is not null)
-            {
-                tools = await client.ListToolsAsync();
-            }
+            IList<McpClientTool> tools = capabilities.Tools is not null
+                ? await client.ListToolsAsync()
+                : Array.Empty<McpClientTool>();
 
-            IList<McpClientPrompt> prompts = Array.Empty<McpClientPrompt>();
-            if (capabilities.Prompts is not null)
-            {
-                prompts = await client.ListPromptsAsync();
-            }
+            IList<McpClientPrompt> prompts = capabilities.Prompts is not null
+                ? await client.ListPromptsAsync()
+                : Array.Empty<McpClientPrompt>();
             entry.Tools.Clear();
             foreach (var tool in tools)
             {


### PR DESCRIPTION
## Summary
- query MCP server capabilities before requesting available tools or prompts

## Testing
- `dotnet build ConsoleChat.sln`
- `dotnet test ConsoleChat.sln -v minimal`
- `dotnet run --project SemanticKernelChat text-completion-test`


------
https://chatgpt.com/codex/tasks/task_e_68708b799d3c8330a380917e2d872c2b