### PR TITLE
Register chat strategies via reflection

### DIFF
--- a/ConsoleChat.Tests/ChatCommandServiceCollectionExtensionsTests.cs
+++ b/ConsoleChat.Tests/ChatCommandServiceCollectionExtensionsTests.cs
@@ -1,0 +1,31 @@
+using Microsoft.Extensions.DependencyInjection;
+using SemanticKernelChat.Console;
+using SemanticKernelChat.Infrastructure;
+using System.Linq;
+
+namespace ConsoleChat.Tests;
+
+public class ChatCommandServiceCollectionExtensionsTests
+{
+    [Fact]
+    public void AddChatCommandStrategies_Registers_All_Strategies()
+    {
+        var services = new ServiceCollection();
+
+        services.AddChatCommandStrategies();
+
+        var strategyType = typeof(IChatCommandStrategy);
+        var expected = strategyType.Assembly.GetTypes()
+            .Where(t => strategyType.IsAssignableFrom(t) && t.IsClass && !t.IsAbstract)
+            .OrderBy(t => t.FullName)
+            .ToArray();
+
+        var actual = services
+            .Where(d => d.ServiceType == strategyType)
+            .Select(d => d.ImplementationType)
+            .OrderBy(t => t!.FullName)
+            .ToArray();
+
+        Assert.Equal(expected, actual);
+    }
+}

--- a/SemanticKernelChat/Infrastructure/ChatCommandServiceCollectionExtensions.cs
+++ b/SemanticKernelChat/Infrastructure/ChatCommandServiceCollectionExtensions.cs
@@ -1,0 +1,27 @@
+using Microsoft.Extensions.DependencyInjection;
+using System.Reflection;
+using System.Linq;
+
+namespace SemanticKernelChat.Infrastructure;
+
+public static class ChatCommandServiceCollectionExtensions
+{
+    /// <summary>
+    /// Registers all <see cref="Console.IChatCommandStrategy"/> implementations found in the
+    /// <c>SemanticKernelChat</c> assembly as singletons.
+    /// </summary>
+    /// <param name="services">The service collection to add registrations to.</param>
+    public static IServiceCollection AddChatCommandStrategies(this IServiceCollection services)
+    {
+        var strategyType = typeof(SemanticKernelChat.Console.IChatCommandStrategy);
+        var assembly = strategyType.Assembly;
+
+        foreach (var type in assembly.GetTypes()
+            .Where(t => strategyType.IsAssignableFrom(t) && t.IsClass && !t.IsAbstract))
+        {
+            services.AddSingleton(strategyType, type);
+        }
+
+        return services;
+    }
+}

--- a/SemanticKernelChat/Program.cs
+++ b/SemanticKernelChat/Program.cs
@@ -37,13 +37,7 @@ builder.Services.AddSingleton<IReadOnlyList<AIFunction>>(provider =>
 #pragma warning restore SKEXP0001
 });
 
-builder.Services.AddSingleton<IChatCommandStrategy, DebugCommandStrategy>();
-builder.Services.AddSingleton<IChatCommandStrategy, ExitCommandStrategy>();
-builder.Services.AddSingleton<IChatCommandStrategy, ListToolsCommandStrategy>();
-builder.Services.AddSingleton<IChatCommandStrategy, ListPromptsCommandStrategy>();
-builder.Services.AddSingleton<IChatCommandStrategy, SetMcpServerStateCommandStrategy>();
-builder.Services.AddSingleton<IChatCommandStrategy, ToggleMcpServerCommandStrategy>();
-builder.Services.AddSingleton<IChatCommandStrategy, UsePromptCommandStrategy>();
+builder.Services.AddChatCommandStrategies();
 
 builder.Services.AddSingleton<ITextCompletion, CommandCompletion>();
 


### PR DESCRIPTION
## Summary
- add `ChatCommandServiceCollectionExtensions` for reflection-based registration of `IChatCommandStrategy`
- use new extension in `Program.cs`
- test that all strategies are registered

## Testing
- `dotnet build ConsoleChat.sln`
- `dotnet test ConsoleChat.sln -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_68786f6e944483308e0ea7c6d24248b9