### PR TITLE
Add NuGet publish workflow for MCP server

### DIFF
--- a/.github/workflows/publish-mcpserver.yml
+++ b/.github/workflows/publish-mcpserver.yml
@@ -1,0 +1,27 @@
+name: Publish MCP Server
+
+on:
+  push:
+    tags:
+      - 'mcpserver-v*'
+  workflow_dispatch:
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '8.0.x'
+      - name: Restore
+        run: dotnet restore ConsoleChat.sln
+      - name: Build
+        run: dotnet build --no-restore ConsoleChat.sln -c Release
+      - name: Pack
+        run: dotnet pack McpServer/McpServer.csproj -c Release -o ./artifacts
+      - name: Publish to NuGet
+        env:
+          NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
+        run: dotnet nuget push ./artifacts/*.nupkg --source https://api.nuget.org/v3/index.json --api-key $NUGET_API_KEY --skip-duplicate

--- a/.mcp/server.json
+++ b/.mcp/server.json
@@ -1,0 +1,20 @@
+{
+  "description": "Example MCP server providing basic utility tools",
+  "name": "io.github.consolechat/McpServer",
+  "packages": [
+    {
+      "registry_name": "nuget",
+      "name": "ConsoleChat.McpServer",
+      "version": "0.1.0",
+      "package_arguments": [],
+      "environment_variables": []
+    }
+  ],
+  "repository": {
+    "url": "https://github.com/yourusername/console-chat",
+    "source": "github"
+  },
+  "version_detail": {
+    "version": "0.1.0"
+  }
+}

--- a/McpServer/McpServer.csproj
+++ b/McpServer/McpServer.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
+    <PackageId>ConsoleChat.McpServer</PackageId>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow that packs and publishes the MCP server on tag push
- specify a PackageId for `McpServer`
- provide example `.mcp/server.json` metadata

## Testing
- `dotnet restore ConsoleChat.sln`
- `dotnet build ConsoleChat.sln`
- `dotnet test ConsoleChat.sln -v minimal`
- `dotnet run --project SemanticKernelChat text-completion-test`

------
https://chatgpt.com/codex/tasks/task_e_687d4dff56188330b0a9b6d412d115e8