### PR TITLE
Fix McpServerState race condition and document TypeRegistrar blocking call

### DIFF
--- a/ConsoleChat.Tests/TestUtilities/CreatePrompt.cs
+++ b/ConsoleChat.Tests/TestUtilities/CreatePrompt.cs
@@ -17,9 +17,9 @@ internal static class PromptFactory
         var entry = new McpServerState.ServerEntry
         {
             Enabled = true,
-            Status = ServerStatus.Ready
+            Status = ServerStatus.Ready,
+            Prompts = new[] { clientPrompt }
         };
-        entry.Prompts.Add(clientPrompt);
         var dict = new ConcurrentDictionary<string, McpServerState.ServerEntry>(StringComparer.OrdinalIgnoreCase)
         {
             ["server"] = entry

--- a/SemanticKernelChat/Infrastructure/McpServerManager.cs
+++ b/SemanticKernelChat/Infrastructure/McpServerManager.cs
@@ -104,16 +104,9 @@ public sealed class McpServerManager : IAsyncDisposable
             IList<McpClientPrompt> prompts = capabilities.Prompts is not null
                 ? await client.ListPromptsAsync()
                 : Array.Empty<McpClientPrompt>();
-            entry.Tools.Clear();
-            foreach (var tool in tools)
-            {
-                entry.Tools.Add(tool);
-            }
-            entry.Prompts.Clear();
-            foreach (var prompt in prompts)
-            {
-                entry.Prompts.Add(prompt);
-            }
+
+            entry.Tools = tools.ToList();
+            entry.Prompts = prompts.ToList();
             entry.Status = ServerStatus.Ready;
         }
         catch (Exception ex)

--- a/SemanticKernelChat/Infrastructure/McpServerState.cs
+++ b/SemanticKernelChat/Infrastructure/McpServerState.cs
@@ -22,8 +22,8 @@ public sealed class McpServerState
 {
     internal sealed class ServerEntry
     {
-        public IList<McpClientTool> Tools { get; } = new List<McpClientTool>();
-        public IList<McpClientPrompt> Prompts { get; } = new List<McpClientPrompt>();
+        public IReadOnlyList<McpClientTool> Tools { get; set; } = Array.Empty<McpClientTool>();
+        public IReadOnlyList<McpClientPrompt> Prompts { get; set; } = Array.Empty<McpClientPrompt>();
         public bool Enabled { get; set; }
         public ServerStatus Status { get; set; } = ServerStatus.None;
         public string? FailureReason { get; set; }

--- a/SemanticKernelChat/Infrastructure/TypeRegistrar.cs
+++ b/SemanticKernelChat/Infrastructure/TypeRegistrar.cs
@@ -44,6 +44,9 @@ public sealed class TypeRegistrar : ITypeRegistrar
         if (_builder is not null)
         {
             _host = _builder.Build();
+            // We must block here because Spectre.Console.Cli's ITypeRegistrar.Build() is synchronous,
+            // and we need to ensure the IHost and its background services are started before any
+            // command can be resolved and executed.
             _host.StartAsync().GetAwaiter().GetResult();
             _provider = _host.Services;
             return new TypeResolver(_provider, true, _host);


### PR DESCRIPTION
This PR addresses code review feedback:

1.  **TypeRegistrar.cs**: Added a comment explaining why `_host.StartAsync().GetAwaiter().GetResult()` is necessary (Spectre.Console.Cli's `ITypeRegistrar.Build()` is synchronous).
2.  **McpServerState.cs**: Fixed a race condition where `Tools` and `Prompts` lists were modified (Clear/Add) while being iterated by `GetTools()`.
    *   Changed `Tools` and `Prompts` properties in `ServerEntry` to `IReadOnlyList<T>` with a public setter.
    *   Updated `McpServerManager.cs` to create new lists and assign them atomically instead of modifying the existing list in-place.
    *   Updated `ConsoleChat.Tests` to accommodate the API change.

---
*PR created automatically by Jules for task [4512863746951602088](https://jules.google.com/task/4512863746951602088) started by @g1ddy*