### PR TITLE
Refactor prompt suggestion parsing and update tests

### DIFF
--- a/ConsoleChat.Tests/TestUtilities/CreatePrompt.cs
+++ b/ConsoleChat.Tests/TestUtilities/CreatePrompt.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using System.Reflection;
 using ModelContextProtocol.Client;
 using ModelContextProtocol.Protocol;
+using NSubstitute;
 using SemanticKernelChat.Infrastructure;
 
 namespace ConsoleChat.Tests.TestUtilities;
@@ -12,7 +13,7 @@ internal static class PromptFactory
     {
         var prompt = new Prompt { Name = name, Description = string.Empty, Arguments = new() };
         var ctor = typeof(McpClientPrompt).GetConstructor(BindingFlags.NonPublic | BindingFlags.Instance, null, new[] { typeof(IMcpClient), typeof(Prompt) }, null)!;
-        var clientPrompt = (McpClientPrompt)ctor.Invoke(new object?[] { null, prompt });
+        var clientPrompt = (McpClientPrompt)ctor.Invoke(new object?[] { Substitute.For<IMcpClient>(), prompt });
         var entry = new McpServerState.ServerEntry
         {
             Enabled = true,
@@ -40,7 +41,7 @@ internal static class PromptFactory
         foreach (var name in names)
         {
             var prompt = new Prompt { Name = name, Description = string.Empty, Arguments = new() };
-            var clientPrompt = (McpClientPrompt)ctor.Invoke(new object?[] { null, prompt });
+            var clientPrompt = (McpClientPrompt)ctor.Invoke(new object?[] { Substitute.For<IMcpClient>(), prompt });
             entry.Prompts.Add(clientPrompt);
         }
 

--- a/SemanticKernelChat/Console/Strategies/SuggestPromptsCommandStrategy.cs
+++ b/SemanticKernelChat/Console/Strategies/SuggestPromptsCommandStrategy.cs
@@ -1,3 +1,4 @@
+using System.Text.RegularExpressions;
 using Microsoft.Extensions.AI;
 using ModelContextProtocol.Protocol;
 using SemanticKernelChat.Infrastructure;
@@ -60,9 +61,10 @@ public sealed class SuggestPromptsCommandStrategy : IChatCommandStrategy
                     console.WriteLine(message.Content.Text ?? string.Empty);
                 }
             }
-            catch
+            catch (Exception ex)
             {
-                // Ignore prompts that cannot be retrieved in tests
+                // Prompts might fail to be retrieved. Inform the user and log for diagnostics.
+                console.DisplayError(ex);
             }
         }
 
@@ -82,6 +84,6 @@ public sealed class SuggestPromptsCommandStrategy : IChatCommandStrategy
             return Array.Empty<string>();
         }
         var lines = text.Split(new[] { '\n', '\r' }, StringSplitOptions.RemoveEmptyEntries);
-        return lines.Select(l => l.Trim().TrimStart('-', '*').Trim()).Where(l => l.Length > 0).Take(3);
+        return lines.Select(l => Regex.Replace(l.Trim(), @"^\s*(\d+\.|[-*])\s*", "")).Where(l => l.Length > 0).Take(3);
     }
 }


### PR DESCRIPTION
- Replaced brittle string manipulation with regex for parsing suggestion prompts to handle list markers correctly.
- Updated `SuggestPromptsCommandStrategy` to display errors instead of swallowing exceptions.
- Updated `CreatePrompt` test utility to use `NSubstitute` for `IMcpClient` instead of passing `null`.

---
*PR created automatically by Jules for task [12234855841512929059](https://jules.google.com/task/12234855841512929059) started by @g1ddy*