### PR TITLE
🧹 Resolve resource leak in McpToolCollection

### DIFF
--- a/ConsoleChat.Tests/McpIntegrationTests.cs
+++ b/ConsoleChat.Tests/McpIntegrationTests.cs
@@ -24,7 +24,7 @@ public class McpIntegrationTests
     [Fact]
     public async Task Tools_Are_Exposed_From_McpServer()
     {
-        var toolCollection = await McpToolCollection.CreateAsync(_config, NullLogger<McpServerState>.Instance);
+        await using var toolCollection = await McpToolCollection.CreateAsync(_config, NullLogger<McpServerState>.Instance);
         await WaitForToolsAsync(toolCollection, 5);
         var tools = toolCollection.Tools;
 
@@ -58,7 +58,7 @@ public class McpIntegrationTests
 
         try
         {
-            var toolCollection = await McpToolCollection.CreateAsync(_config, NullLogger<McpServerState>.Instance);
+            await using var toolCollection = await McpToolCollection.CreateAsync(_config, NullLogger<McpServerState>.Instance);
             await WaitForToolsAsync(toolCollection, 5);
             Assert.True(toolCollection.Tools.Count >= 5);
         }

--- a/SemanticKernelChat/Infrastructure/McpPromptCollection.cs
+++ b/SemanticKernelChat/Infrastructure/McpPromptCollection.cs
@@ -10,7 +10,7 @@ namespace SemanticKernelChat.Infrastructure;
 /// <summary>
 /// Holds prompts from MCP servers and manages underlying resources.
 /// </summary>
-public sealed class McpPromptCollection
+public sealed class McpPromptCollection : IAsyncDisposable
 {
     private readonly McpServerManager _manager;
 
@@ -28,6 +28,11 @@ public sealed class McpPromptCollection
     public bool IsServerEnabled(string name) => _manager.State.IsServerEnabled(name);
 
     public void SetServerEnabled(string name, bool enabled) => _manager.SetServerEnabled(name, enabled);
+
+    public async ValueTask DisposeAsync()
+    {
+        await _manager.DisposeAsync();
+    }
 
     public static async Task<McpPromptCollection> CreateAsync(
         IConfiguration configuration,

--- a/SemanticKernelChat/Infrastructure/McpServerManager.cs
+++ b/SemanticKernelChat/Infrastructure/McpServerManager.cs
@@ -17,6 +17,7 @@ public sealed class McpServerManager : IAsyncDisposable
     private readonly ConcurrentDictionary<string, Task> _loadTasks = new();
     private readonly List<IAsyncDisposable> _disposables = new();
     private readonly ILogger<McpServerState> _logger;
+    private bool _disposed;
 
     private McpServerManager(McpServerState state, Dictionary<string, McpServerConfig> configs, ILogger<McpServerState> logger)
     {
@@ -119,9 +120,16 @@ public sealed class McpServerManager : IAsyncDisposable
 
     public async ValueTask DisposeAsync()
     {
+        if (_disposed)
+        {
+            return;
+        }
+
         foreach (var disposable in Enumerable.Reverse(_disposables))
         {
             await disposable.DisposeAsync();
         }
+
+        _disposed = true;
     }
 }

--- a/SemanticKernelChat/Infrastructure/McpToolCollection.cs
+++ b/SemanticKernelChat/Infrastructure/McpToolCollection.cs
@@ -10,7 +10,7 @@ namespace SemanticKernelChat.Infrastructure;
 /// <summary>
 /// Holds MCP tools and disposes underlying transports when no longer needed.
 /// </summary>
-public sealed class McpToolCollection
+public sealed class McpToolCollection : IAsyncDisposable
 {
     private readonly McpServerManager _manager;
 
@@ -28,6 +28,11 @@ public sealed class McpToolCollection
     public bool IsServerEnabled(string name) => _manager.State.IsServerEnabled(name);
 
     public void SetServerEnabled(string name, bool enabled) => _manager.SetServerEnabled(name, enabled);
+
+    public async ValueTask DisposeAsync()
+    {
+        await _manager.DisposeAsync();
+    }
 
     public static async Task<McpToolCollection> CreateAsync(
         IConfiguration configuration,


### PR DESCRIPTION
Implemented `IAsyncDisposable` in `McpToolCollection` and `McpPromptCollection` to address a resource leak where the underlying `McpServerManager` (and its client transports) were not being disposed. Also made `McpServerManager.DisposeAsync` idempotent and updated integration tests to verify the fix.

---
*PR created automatically by Jules for task [8636408309853247392](https://jules.google.com/task/8636408309853247392) started by @g1ddy*