### PR TITLE
⚡ Harden and deduplicate McpServerState caching

### DIFF
--- a/SemanticKernelChat/Infrastructure/McpServerManager.cs
+++ b/SemanticKernelChat/Infrastructure/McpServerManager.cs
@@ -86,9 +86,8 @@ public sealed class McpServerManager : IAsyncDisposable
 
     private async Task LoadServerAsync(string name, CancellationToken cancellationToken = default)
     {
-        var entry = _state.GetEntry(name)!;
         var config = _configs[name];
-        entry.Status = ServerStatus.Loading;
+        _state.UpdateServerStatus(name, ServerStatus.Loading);
         try
         {
             var transport = await McpClientHelper.CreateTransportAsync(name, config, cancellationToken: cancellationToken);
@@ -105,14 +104,12 @@ public sealed class McpServerManager : IAsyncDisposable
                 ? await client.ListPromptsAsync()
                 : Array.Empty<McpClientPrompt>();
 
-            entry.Tools = tools.ToList();
-            entry.Prompts = prompts.ToList();
-            entry.Status = ServerStatus.Ready;
+            _state.UpdateServerToolsAndPrompts(name, tools.ToList(), prompts.ToList());
+            _state.UpdateServerStatus(name, ServerStatus.Ready);
         }
         catch (Exception ex)
         {
-            entry.Status = ServerStatus.Failed;
-            entry.FailureReason = ex.Message;
+            _state.UpdateServerStatus(name, ServerStatus.Failed, ex.Message);
             _logger.LogError(ex, "Error loading MCP server {ServerName}", name);
         }
     }

--- a/SemanticKernelChat/Infrastructure/McpServerState.cs
+++ b/SemanticKernelChat/Infrastructure/McpServerState.cs
@@ -37,6 +37,11 @@ public sealed class McpServerState
     // This class is intended to be accessed by background load tasks and UI threads simultaneously.
     private readonly ConcurrentDictionary<string, ServerEntry> _servers;
 
+    private long _version;
+    private volatile Tuple<long, IReadOnlyList<McpClientTool>>? _toolsCache;
+    private volatile Tuple<long, IReadOnlyList<McpClientPrompt>>? _promptsCache;
+    private readonly object _lock = new();
+
     internal McpServerState()
         : this(new ConcurrentDictionary<string, ServerEntry>(StringComparer.OrdinalIgnoreCase))
     {
@@ -58,21 +63,75 @@ public sealed class McpServerState
         if (_servers.TryGetValue(name, out var entry))
         {
             entry.Enabled = enabled;
+            Interlocked.Increment(ref _version);
+        }
+    }
+
+    internal void UpdateServerStatus(string name, ServerStatus status, string? failureReason = null)
+    {
+        if (_servers.TryGetValue(name, out var entry))
+        {
+            entry.Status = status;
+            entry.FailureReason = failureReason;
+            Interlocked.Increment(ref _version);
+        }
+    }
+
+    internal void UpdateServerToolsAndPrompts(string name, IReadOnlyList<McpClientTool> tools, IReadOnlyList<McpClientPrompt> prompts)
+    {
+        if (_servers.TryGetValue(name, out var entry))
+        {
+            entry.Tools = tools;
+            entry.Prompts = prompts;
+            Interlocked.Increment(ref _version);
         }
     }
 
     public IReadOnlyList<McpClientTool> GetTools()
     {
-        return _servers.Where(p => p.Value.Enabled && p.Value.Status == ServerStatus.Ready)
-            .SelectMany(p => p.Value.Tools)
-            .ToList();
+        return GetCachedItems(
+            () => _toolsCache,
+            value => _toolsCache = value,
+            e => e.Tools);
     }
 
     public IReadOnlyList<McpClientPrompt> GetPrompts()
     {
-        return _servers.Where(p => p.Value.Enabled && p.Value.Status == ServerStatus.Ready)
-            .SelectMany(p => p.Value.Prompts)
-            .ToList();
+        return GetCachedItems(
+            () => _promptsCache,
+            value => _promptsCache = value,
+            e => e.Prompts);
+    }
+
+    private IReadOnlyList<T> GetCachedItems<T>(
+        Func<Tuple<long, IReadOnlyList<T>>?> getCache,
+        Action<Tuple<long, IReadOnlyList<T>>> setCache,
+        Func<ServerEntry, IEnumerable<T>> selector)
+    {
+        long currentVersion = Interlocked.Read(ref _version);
+        var localCache = getCache();
+        if (localCache?.Item1 == currentVersion)
+        {
+            return localCache.Item2;
+        }
+
+        lock (_lock)
+        {
+            currentVersion = Interlocked.Read(ref _version);
+            localCache = getCache();
+            if (localCache?.Item1 == currentVersion)
+            {
+                return localCache.Item2;
+            }
+
+            var newItems = _servers.Values
+                .Where(e => e.Enabled && e.Status == ServerStatus.Ready)
+                .SelectMany(selector)
+                .ToList();
+
+            setCache(Tuple.Create(currentVersion, (IReadOnlyList<T>)newItems));
+            return newItems;
+        }
     }
 
     internal IReadOnlyList<McpServerInfo> GetServerInfos()


### PR DESCRIPTION
This update addresses the PR feedback by:
1. **Hardening the caching mechanism:** Replaced the previous double-checked locking that used separate fields for version and list with a `volatile Tuple<long, IReadOnlyList<T>>`. This ensures that the cache version and the list itself are always seen together as an atomic unit by other threads, resolving a potential race condition.
2. **Deduplicating logic:** Extracted the caching and list-building logic into a generic `GetCachedItems` method, which is now used by both `GetTools` and `GetPrompts`. This improves maintainability and reduces code duplication.

Verified that the build passes and all 66 functional tests are successful.

---
*PR created automatically by Jules for task [17434476972982399140](https://jules.google.com/task/17434476972982399140) started by @g1ddy*