### PR TITLE
Fix compilation errors in ConsoleChat.Tests

### DIFF
--- a/ConsoleChat.Tests/TestUtilities/CreatePrompt.cs
+++ b/ConsoleChat.Tests/TestUtilities/CreatePrompt.cs
@@ -39,14 +39,16 @@ internal static class PromptFactory
         };
         var ctor = typeof(McpClientPrompt).GetConstructor(BindingFlags.NonPublic | BindingFlags.Instance, null, new[] { typeof(IMcpClient), typeof(Prompt) }, null)!;
 
+        var prompts = new List<McpClientPrompt>();
         foreach (var name in names)
         {
             var prompt = new Prompt { Name = name, Description = string.Empty, Arguments = new() };
             var clientPrompt = (McpClientPrompt)ctor.Invoke(new object?[] { Substitute.For<IMcpClient>(), prompt });
-            entry.Prompts.Add(clientPrompt);
+            prompts.Add(clientPrompt);
         }
+        entry.Prompts = prompts;
 
-        var dict = new Dictionary<string, McpServerState.ServerEntry>(StringComparer.OrdinalIgnoreCase)
+        var dict = new ConcurrentDictionary<string, McpServerState.ServerEntry>(StringComparer.OrdinalIgnoreCase)
         {
             ["server"] = entry
         };


### PR DESCRIPTION
This PR fixes compilation errors in `ConsoleChat.Tests/TestUtilities/CreatePrompt.cs`.
The changes include:
1.  Using a `List<McpClientPrompt>` to accumulate prompts before assigning them to the read-only `Prompts` property of `ServerEntry`.
2.  Instantiating `McpServerState` with a `ConcurrentDictionary` as required by its constructor.

These changes ensure that `ConsoleChat.Tests` project compiles successfully and tests can run. All 89 tests in `ConsoleChat.Tests` passed.

---
*PR created automatically by Jules for task [15605925439445968112](https://jules.google.com/task/15605925439445968112) started by @g1ddy*