### PR TITLE
🔒 Fix insufficient token validation in PassThroughAuthenticationHandler

### DIFF
--- a/RaindropServer.Tests/AuthTests.cs
+++ b/RaindropServer.Tests/AuthTests.cs
@@ -3,10 +3,13 @@ using System.Security.Claims;
 using System.Text.Encodings.Web;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using RaindropServer.Common;
 using RaindropServer.Tests.Common;
+using RaindropServer.User;
 using Xunit;
 using NSubstitute;
 
@@ -14,6 +17,18 @@ namespace RaindropServer.Tests;
 
 public class AuthTests
 {
+    private readonly IMemoryCache _cache;
+    private readonly IOptionsMonitor<AuthenticationSchemeOptions> _optionsMonitor;
+    private readonly UrlEncoder _encoder;
+
+    public AuthTests()
+    {
+        _cache = new MemoryCache(new MemoryCacheOptions());
+        _optionsMonitor = Substitute.For<IOptionsMonitor<AuthenticationSchemeOptions>>();
+        _optionsMonitor.Get(Arg.Any<string>()).Returns(new AuthenticationSchemeOptions());
+        _encoder = UrlEncoder.Default;
+    }
+
     [Fact]
     public void HttpContextTokenProvider_ReturnsToken_ForBearerScheme()
     {
@@ -51,17 +66,19 @@ public class AuthTests
     }
 
     [Fact]
-    public async Task PassThroughAuthenticationHandler_ReturnsSuccess_WhenHeaderPresentAndValidGuid()
+    public async Task PassThroughAuthenticationHandler_ReturnsSuccess_WhenTokenIsValidatedByApi()
     {
         // Arrange
-        var optionsMonitor = Substitute.For<IOptionsMonitor<AuthenticationSchemeOptions>>();
-        optionsMonitor.Get(Arg.Any<string>()).Returns(new AuthenticationSchemeOptions());
-        var logger = NullLoggerFactory.Instance;
-        var encoder = UrlEncoder.Default;
+        var userApi = Substitute.For<IUserApi>();
+        userApi.GetAsync().Returns(new ItemResponse<UserInfo>(true, new UserInfo()));
 
-        var handler = new PassThroughAuthenticationHandler(optionsMonitor, logger, encoder);
+        var services = new ServiceCollection();
+        services.AddSingleton(userApi);
+        var serviceProvider = services.BuildServiceProvider();
 
-        var context = new DefaultHttpContext();
+        var handler = new PassThroughAuthenticationHandler(_optionsMonitor, NullLoggerFactory.Instance, _encoder, _cache);
+
+        var context = new DefaultHttpContext { RequestServices = serviceProvider };
         var validGuid = Guid.NewGuid().ToString();
         context.Request.Headers["Authorization"] = $"Bearer {validGuid}";
 
@@ -72,20 +89,75 @@ public class AuthTests
 
         // Assert
         Assert.True(result.Succeeded);
-        Assert.NotNull(result.Principal);
         Assert.Equal("RaindropUser", result.Principal?.Identity?.Name);
+        await userApi.Received(1).GetAsync();
+    }
+
+    [Fact]
+    public async Task PassThroughAuthenticationHandler_ReturnsSuccess_WhenTokenIsInCache()
+    {
+        // Arrange
+        var userApi = Substitute.For<IUserApi>();
+        var validGuid = Guid.NewGuid().ToString();
+        _cache.Set($"TokenValidation_{validGuid}", true);
+
+        var services = new ServiceCollection();
+        services.AddSingleton(userApi);
+        var serviceProvider = services.BuildServiceProvider();
+
+        var handler = new PassThroughAuthenticationHandler(_optionsMonitor, NullLoggerFactory.Instance, _encoder, _cache);
+
+        var context = new DefaultHttpContext { RequestServices = serviceProvider };
+        context.Request.Headers["Authorization"] = $"Bearer {validGuid}";
+
+        await handler.InitializeAsync(new AuthenticationScheme("PassThrough", "PassThrough", typeof(PassThroughAuthenticationHandler)), context);
+
+        // Act
+        var result = await handler.AuthenticateAsync();
+
+        // Assert
+        Assert.True(result.Succeeded);
+        await userApi.DidNotReceive().GetAsync();
+    }
+
+    [Fact]
+    public async Task PassThroughAuthenticationHandler_ReturnsFail_WhenApiReturnsFailure()
+    {
+        // Arrange
+        var userApi = Substitute.For<IUserApi>();
+        userApi.GetAsync().Returns(new ItemResponse<UserInfo>(false, null!));
+
+        var services = new ServiceCollection();
+        services.AddSingleton(userApi);
+        var serviceProvider = services.BuildServiceProvider();
+
+        var handler = new PassThroughAuthenticationHandler(_optionsMonitor, NullLoggerFactory.Instance, _encoder, _cache);
+
+        var context = new DefaultHttpContext { RequestServices = serviceProvider };
+        var validGuid = Guid.NewGuid().ToString();
+        context.Request.Headers["Authorization"] = $"Bearer {validGuid}";
+
+        await handler.InitializeAsync(new AuthenticationScheme("PassThrough", "PassThrough", typeof(PassThroughAuthenticationHandler)), context);
+
+        // Act
+        var result = await handler.AuthenticateAsync();
+
+        // Assert
+        Assert.False(result.Succeeded);
+        Assert.Equal("Invalid Token", result.Failure?.Message);
+        await userApi.Received(1).GetAsync();
+
+        // Verify it was cached as failure
+        var secondResult = await handler.AuthenticateAsync();
+        Assert.False(secondResult.Succeeded);
+        await userApi.Received(1).GetAsync(); // Still only 1 call
     }
 
     [Fact]
     public async Task PassThroughAuthenticationHandler_ReturnsFail_WhenHeaderMissing()
     {
         // Arrange
-        var optionsMonitor = Substitute.For<IOptionsMonitor<AuthenticationSchemeOptions>>();
-        optionsMonitor.Get(Arg.Any<string>()).Returns(new AuthenticationSchemeOptions());
-        var logger = NullLoggerFactory.Instance;
-        var encoder = UrlEncoder.Default;
-
-        var handler = new PassThroughAuthenticationHandler(optionsMonitor, logger, encoder);
+        var handler = new PassThroughAuthenticationHandler(_optionsMonitor, NullLoggerFactory.Instance, _encoder, _cache);
 
         var context = new DefaultHttpContext();
         // No header
@@ -104,12 +176,7 @@ public class AuthTests
     public async Task PassThroughAuthenticationHandler_ReturnsFail_WhenTokenIsNotGuid()
     {
         // Arrange
-        var optionsMonitor = Substitute.For<IOptionsMonitor<AuthenticationSchemeOptions>>();
-        optionsMonitor.Get(Arg.Any<string>()).Returns(new AuthenticationSchemeOptions());
-        var logger = NullLoggerFactory.Instance;
-        var encoder = UrlEncoder.Default;
-
-        var handler = new PassThroughAuthenticationHandler(optionsMonitor, logger, encoder);
+        var handler = new PassThroughAuthenticationHandler(_optionsMonitor, NullLoggerFactory.Instance, _encoder, _cache);
 
         var context = new DefaultHttpContext();
         context.Request.Headers["Authorization"] = "Bearer not-a-guid";

--- a/RaindropServer.Tests/AuthTests.cs
+++ b/RaindropServer.Tests/AuthTests.cs
@@ -3,10 +3,13 @@ using System.Security.Claims;
 using System.Text.Encodings.Web;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using RaindropServer.Common;
 using RaindropServer.Tests.Common;
+using RaindropServer.User;
 using Xunit;
 using NSubstitute;
 
@@ -14,6 +17,18 @@ namespace RaindropServer.Tests;
 
 public class AuthTests
 {
+    private readonly IMemoryCache _cache;
+    private readonly IOptionsMonitor<AuthenticationSchemeOptions> _optionsMonitor;
+    private readonly UrlEncoder _encoder;
+
+    public AuthTests()
+    {
+        _cache = new MemoryCache(new MemoryCacheOptions());
+        _optionsMonitor = Substitute.For<IOptionsMonitor<AuthenticationSchemeOptions>>();
+        _optionsMonitor.Get(Arg.Any<string>()).Returns(new AuthenticationSchemeOptions());
+        _encoder = UrlEncoder.Default;
+    }
+
     [Fact]
     public void HttpContextTokenProvider_ReturnsToken_ForBearerScheme()
     {
@@ -51,17 +66,19 @@ public class AuthTests
     }
 
     [Fact]
-    public async Task PassThroughAuthenticationHandler_ReturnsSuccess_WhenHeaderPresentAndValidGuid()
+    public async Task PassThroughAuthenticationHandler_ReturnsSuccess_WhenTokenIsValidatedByApi()
     {
         // Arrange
-        var optionsMonitor = Substitute.For<IOptionsMonitor<AuthenticationSchemeOptions>>();
-        optionsMonitor.Get(Arg.Any<string>()).Returns(new AuthenticationSchemeOptions());
-        var logger = NullLoggerFactory.Instance;
-        var encoder = UrlEncoder.Default;
+        var userApi = Substitute.For<IUserApi>();
+        userApi.GetAsync().Returns(new ItemResponse<UserInfo>(true, new UserInfo()));
 
-        var handler = new PassThroughAuthenticationHandler(optionsMonitor, logger, encoder);
+        var services = new ServiceCollection();
+        services.AddSingleton(userApi);
+        var serviceProvider = services.BuildServiceProvider();
 
-        var context = new DefaultHttpContext();
+        var handler = new PassThroughAuthenticationHandler(_optionsMonitor, NullLoggerFactory.Instance, _encoder, _cache);
+
+        var context = new DefaultHttpContext { RequestServices = serviceProvider };
         var validGuid = Guid.NewGuid().ToString();
         context.Request.Headers["Authorization"] = $"Bearer {validGuid}";
 
@@ -72,20 +89,69 @@ public class AuthTests
 
         // Assert
         Assert.True(result.Succeeded);
-        Assert.NotNull(result.Principal);
         Assert.Equal("RaindropUser", result.Principal?.Identity?.Name);
+        await userApi.Received(1).GetAsync();
+    }
+
+    [Fact]
+    public async Task PassThroughAuthenticationHandler_ReturnsSuccess_WhenTokenIsInCache()
+    {
+        // Arrange
+        var userApi = Substitute.For<IUserApi>();
+        var validGuid = Guid.NewGuid().ToString();
+        _cache.Set($"TokenValidation_{validGuid}", true);
+
+        var services = new ServiceCollection();
+        services.AddSingleton(userApi);
+        var serviceProvider = services.BuildServiceProvider();
+
+        var handler = new PassThroughAuthenticationHandler(_optionsMonitor, NullLoggerFactory.Instance, _encoder, _cache);
+
+        var context = new DefaultHttpContext { RequestServices = serviceProvider };
+        context.Request.Headers["Authorization"] = $"Bearer {validGuid}";
+
+        await handler.InitializeAsync(new AuthenticationScheme("PassThrough", "PassThrough", typeof(PassThroughAuthenticationHandler)), context);
+
+        // Act
+        var result = await handler.AuthenticateAsync();
+
+        // Assert
+        Assert.True(result.Succeeded);
+        await userApi.DidNotReceive().GetAsync();
+    }
+
+    [Fact]
+    public async Task PassThroughAuthenticationHandler_ReturnsFail_WhenApiReturnsFailure()
+    {
+        // Arrange
+        var userApi = Substitute.For<IUserApi>();
+        userApi.GetAsync().Returns(new ItemResponse<UserInfo>(false, null!));
+
+        var services = new ServiceCollection();
+        services.AddSingleton(userApi);
+        var serviceProvider = services.BuildServiceProvider();
+
+        var handler = new PassThroughAuthenticationHandler(_optionsMonitor, NullLoggerFactory.Instance, _encoder, _cache);
+
+        var context = new DefaultHttpContext { RequestServices = serviceProvider };
+        var validGuid = Guid.NewGuid().ToString();
+        context.Request.Headers["Authorization"] = $"Bearer {validGuid}";
+
+        await handler.InitializeAsync(new AuthenticationScheme("PassThrough", "PassThrough", typeof(PassThroughAuthenticationHandler)), context);
+
+        // Act
+        var result = await handler.AuthenticateAsync();
+
+        // Assert
+        Assert.False(result.Succeeded);
+        Assert.Equal("Invalid Token", result.Failure?.Message);
     }
 
     [Fact]
     public async Task PassThroughAuthenticationHandler_ReturnsFail_WhenHeaderMissing()
     {
         // Arrange
-        var optionsMonitor = Substitute.For<IOptionsMonitor<AuthenticationSchemeOptions>>();
-        optionsMonitor.Get(Arg.Any<string>()).Returns(new AuthenticationSchemeOptions());
-        var logger = NullLoggerFactory.Instance;
-        var encoder = UrlEncoder.Default;
-
-        var handler = new PassThroughAuthenticationHandler(optionsMonitor, logger, encoder);
+        var handler = new PassThroughAuthenticationHandler(_optionsMonitor, NullLoggerFactory.Instance, _encoder, _cache);
 
         var context = new DefaultHttpContext();
         // No header
@@ -104,12 +170,7 @@ public class AuthTests
     public async Task PassThroughAuthenticationHandler_ReturnsFail_WhenTokenIsNotGuid()
     {
         // Arrange
-        var optionsMonitor = Substitute.For<IOptionsMonitor<AuthenticationSchemeOptions>>();
-        optionsMonitor.Get(Arg.Any<string>()).Returns(new AuthenticationSchemeOptions());
-        var logger = NullLoggerFactory.Instance;
-        var encoder = UrlEncoder.Default;
-
-        var handler = new PassThroughAuthenticationHandler(optionsMonitor, logger, encoder);
+        var handler = new PassThroughAuthenticationHandler(_optionsMonitor, NullLoggerFactory.Instance, _encoder, _cache);
 
         var context = new DefaultHttpContext();
         context.Request.Headers["Authorization"] = "Bearer not-a-guid";

--- a/RaindropServer/Common/PassThroughAuthenticationHandler.cs
+++ b/RaindropServer/Common/PassThroughAuthenticationHandler.cs
@@ -1,6 +1,9 @@
 using Microsoft.AspNetCore.Authentication;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
+using RaindropServer.User;
 using System.Security.Claims;
 using System.Text.Encodings.Web;
 
@@ -8,32 +11,36 @@ namespace RaindropServer.Common;
 
 public class PassThroughAuthenticationHandler : AuthenticationHandler<AuthenticationSchemeOptions>
 {
+    private readonly IMemoryCache _cache;
+
     public PassThroughAuthenticationHandler(
         IOptionsMonitor<AuthenticationSchemeOptions> options,
         ILoggerFactory logger,
-        UrlEncoder encoder)
+        UrlEncoder encoder,
+        IMemoryCache cache)
         : base(options, logger, encoder)
     {
+        _cache = cache;
     }
 
-    protected override Task<AuthenticateResult> HandleAuthenticateAsync()
+    protected override async Task<AuthenticateResult> HandleAuthenticateAsync()
     {
         // Check for Authorization header presence
         if (!Request.Headers.TryGetValue("Authorization", out var authHeaderValue))
         {
-            return Task.FromResult(AuthenticateResult.Fail("Missing Authorization Header"));
+            return AuthenticateResult.Fail("Missing Authorization Header");
         }
 
         var authHeader = authHeaderValue.ToString();
         if (string.IsNullOrWhiteSpace(authHeader))
         {
-             return Task.FromResult(AuthenticateResult.Fail("Empty Authorization Header"));
+            return AuthenticateResult.Fail("Empty Authorization Header");
         }
 
         // Validate Scheme
         if (!authHeader.StartsWith("Bearer ", StringComparison.OrdinalIgnoreCase))
         {
-            return Task.FromResult(AuthenticateResult.Fail("Invalid Authentication Scheme"));
+            return AuthenticateResult.Fail("Invalid Authentication Scheme");
         }
 
         var token = authHeader.Substring("Bearer ".Length).Trim();
@@ -41,15 +48,50 @@ public class PassThroughAuthenticationHandler : AuthenticationHandler<Authentica
         // Validate Token Format (GUID)
         if (!Guid.TryParse(token, out _))
         {
-             return Task.FromResult(AuthenticateResult.Fail("Invalid Token Format"));
+            return AuthenticateResult.Fail("Invalid Token Format");
         }
 
-        // Create a user identity.
-        var claims = new[] { new Claim(ClaimTypes.Name, "RaindropUser") };
-        var identity = new ClaimsIdentity(claims, "PassThrough");
-        var principal = new ClaimsPrincipal(identity);
-        var ticket = new AuthenticationTicket(principal, Scheme.Name);
+        // Check Cache
+        string cacheKey = $"TokenValidation_{token}";
+        if (_cache.TryGetValue(cacheKey, out bool isValid))
+        {
+            return isValid ? Success() : AuthenticateResult.Fail("Invalid Token");
+        }
 
-        return Task.FromResult(AuthenticateResult.Success(ticket));
+        // Validate Token with Raindrop API
+        try
+        {
+            var userApi = Context.RequestServices.GetRequiredService<IUserApi>();
+            // The AuthHeaderHandler will automatically pick up the token from HttpContext
+            // but since we are in the authentication handler, the identity is not set yet.
+            // However, AuthHeaderHandler uses ITokenProvider which uses HttpContext.Request.Headers["Authorization"]
+            // which is already present.
+            var response = await userApi.GetAsync();
+
+            if (response.Result)
+            {
+                _cache.Set(cacheKey, true, TimeSpan.FromMinutes(5));
+                return Success();
+            }
+            else
+            {
+                _cache.Set(cacheKey, false, TimeSpan.FromMinutes(1));
+                return AuthenticateResult.Fail("Invalid Token");
+            }
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Error validating token with Raindrop API");
+            return AuthenticateResult.Fail("Token validation failed");
+        }
+
+        AuthenticateResult Success()
+        {
+            var claims = new[] { new Claim(ClaimTypes.Name, "RaindropUser") };
+            var identity = new ClaimsIdentity(claims, "PassThrough");
+            var principal = new ClaimsPrincipal(identity);
+            var ticket = new AuthenticationTicket(principal, Scheme.Name);
+            return AuthenticateResult.Success(ticket);
+        }
     }
 }

--- a/RaindropServer/Common/PassThroughAuthenticationHandler.cs
+++ b/RaindropServer/Common/PassThroughAuthenticationHandler.cs
@@ -1,6 +1,9 @@
 using Microsoft.AspNetCore.Authentication;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
+using RaindropServer.User;
 using System.Security.Claims;
 using System.Text.Encodings.Web;
 
@@ -8,32 +11,36 @@ namespace RaindropServer.Common;
 
 public class PassThroughAuthenticationHandler : AuthenticationHandler<AuthenticationSchemeOptions>
 {
+    private readonly IMemoryCache _cache;
+
     public PassThroughAuthenticationHandler(
         IOptionsMonitor<AuthenticationSchemeOptions> options,
         ILoggerFactory logger,
-        UrlEncoder encoder)
+        UrlEncoder encoder,
+        IMemoryCache cache)
         : base(options, logger, encoder)
     {
+        _cache = cache;
     }
 
-    protected override Task<AuthenticateResult> HandleAuthenticateAsync()
+    protected override async Task<AuthenticateResult> HandleAuthenticateAsync()
     {
         // Check for Authorization header presence
         if (!Request.Headers.TryGetValue("Authorization", out var authHeaderValue))
         {
-            return Task.FromResult(AuthenticateResult.Fail("Missing Authorization Header"));
+            return AuthenticateResult.Fail("Missing Authorization Header");
         }
 
         var authHeader = authHeaderValue.ToString();
         if (string.IsNullOrWhiteSpace(authHeader))
         {
-             return Task.FromResult(AuthenticateResult.Fail("Empty Authorization Header"));
+            return AuthenticateResult.Fail("Empty Authorization Header");
         }
 
         // Validate Scheme
         if (!authHeader.StartsWith("Bearer ", StringComparison.OrdinalIgnoreCase))
         {
-            return Task.FromResult(AuthenticateResult.Fail("Invalid Authentication Scheme"));
+            return AuthenticateResult.Fail("Invalid Authentication Scheme");
         }
 
         var token = authHeader.Substring("Bearer ".Length).Trim();
@@ -41,15 +48,49 @@ public class PassThroughAuthenticationHandler : AuthenticationHandler<Authentica
         // Validate Token Format (GUID)
         if (!Guid.TryParse(token, out _))
         {
-             return Task.FromResult(AuthenticateResult.Fail("Invalid Token Format"));
+            return AuthenticateResult.Fail("Invalid Token Format");
         }
 
-        // Create a user identity.
-        var claims = new[] { new Claim(ClaimTypes.Name, "RaindropUser") };
-        var identity = new ClaimsIdentity(claims, "PassThrough");
-        var principal = new ClaimsPrincipal(identity);
-        var ticket = new AuthenticationTicket(principal, Scheme.Name);
+        // Check Cache
+        string cacheKey = $"TokenValidation_{token}";
+        if (_cache.TryGetValue(cacheKey, out bool isValid) && isValid)
+        {
+            return Success();
+        }
 
-        return Task.FromResult(AuthenticateResult.Success(ticket));
+        // Validate Token with Raindrop API
+        try
+        {
+            var userApi = Context.RequestServices.GetRequiredService<IUserApi>();
+            // The AuthHeaderHandler will automatically pick up the token from HttpContext
+            // but since we are in the authentication handler, the identity is not set yet.
+            // However, AuthHeaderHandler uses ITokenProvider which uses HttpContext.Request.Headers["Authorization"]
+            // which is already present.
+            var response = await userApi.GetAsync();
+
+            if (response.Result)
+            {
+                _cache.Set(cacheKey, true, TimeSpan.FromMinutes(5));
+                return Success();
+            }
+            else
+            {
+                return AuthenticateResult.Fail("Invalid Token");
+            }
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "Error validating token with Raindrop API");
+            return AuthenticateResult.Fail("Token validation failed");
+        }
+
+        AuthenticateResult Success()
+        {
+            var claims = new[] { new Claim(ClaimTypes.Name, "RaindropUser") };
+            var identity = new ClaimsIdentity(claims, "PassThrough");
+            var principal = new ClaimsPrincipal(identity);
+            var ticket = new AuthenticationTicket(principal, Scheme.Name);
+            return AuthenticateResult.Success(ticket);
+        }
     }
 }

--- a/RaindropServer/Common/PassThroughAuthenticationHandler.cs
+++ b/RaindropServer/Common/PassThroughAuthenticationHandler.cs
@@ -11,6 +11,10 @@ namespace RaindropServer.Common;
 
 public class PassThroughAuthenticationHandler : AuthenticationHandler<AuthenticationSchemeOptions>
 {
+    private const string CacheKeyPrefix = "TokenValidation_";
+    private static readonly TimeSpan SuccessfulValidationCacheDuration = TimeSpan.FromMinutes(5);
+    private static readonly TimeSpan FailedValidationCacheDuration = TimeSpan.FromMinutes(1);
+
     private readonly IMemoryCache _cache;
 
     public PassThroughAuthenticationHandler(
@@ -52,7 +56,7 @@ public class PassThroughAuthenticationHandler : AuthenticationHandler<Authentica
         }
 
         // Check Cache
-        string cacheKey = $"TokenValidation_{token}";
+        string cacheKey = $"{CacheKeyPrefix}{token}";
         if (_cache.TryGetValue(cacheKey, out bool isValid))
         {
             return isValid ? Success() : AuthenticateResult.Fail("Invalid Token");
@@ -70,12 +74,12 @@ public class PassThroughAuthenticationHandler : AuthenticationHandler<Authentica
 
             if (response.Result)
             {
-                _cache.Set(cacheKey, true, TimeSpan.FromMinutes(5));
+                _cache.Set(cacheKey, true, SuccessfulValidationCacheDuration);
                 return Success();
             }
             else
             {
-                _cache.Set(cacheKey, false, TimeSpan.FromMinutes(1));
+                _cache.Set(cacheKey, false, FailedValidationCacheDuration);
                 return AuthenticateResult.Fail("Invalid Token");
             }
         }

--- a/RaindropServer/Program.cs
+++ b/RaindropServer/Program.cs
@@ -10,6 +10,8 @@ builder.Logging.AddConsole(options =>
     options.LogToStandardErrorThreshold = LogLevel.Trace;
 });
 
+builder.Services.AddMemoryCache();
+
 // Configure Authentication
 builder.Services.AddAuthentication("PassThrough")
     .AddScheme<AuthenticationSchemeOptions, PassThroughAuthenticationHandler>("PassThrough", null);


### PR DESCRIPTION
🎯 **What:** Fixed insufficient token validation in `PassThroughAuthenticationHandler`.
⚠️ **Risk:** Any valid GUID was previously accepted as a token, allowing unauthorized access.
🛡️ **Solution:** The handler now validates Bearer tokens by calling the Raindrop API. It uses `IMemoryCache` to avoid redundant external calls, caching successful results for 5 minutes.

---
*PR created automatically by Jules for task [1250597816258614383](https://jules.google.com/task/1250597816258614383) started by @g1ddy*