### PR TITLE
🧪 Add unit tests for FiltersTools.GetAvailableFiltersAsync

### DIFF
--- a/RaindropServer.Tests/FiltersToolsTests.cs
+++ b/RaindropServer.Tests/FiltersToolsTests.cs
@@ -1,0 +1,61 @@
+using NSubstitute;
+using RaindropServer.Filters;
+
+namespace RaindropServer.Tests;
+
+public class FiltersToolsTests
+{
+    private readonly IFiltersApi _api;
+    private readonly FiltersTools _sut;
+
+    public FiltersToolsTests()
+    {
+        _api = Substitute.For<IFiltersApi>();
+        _sut = new FiltersTools(_api);
+    }
+
+    [Fact]
+    public async Task GetAvailableFiltersAsync_InvalidTagsSort_ThrowsArgumentOutOfRangeException()
+    {
+        // Act & Assert
+        var exception = await Assert.ThrowsAsync<ArgumentOutOfRangeException>(() =>
+            _sut.GetAvailableFiltersAsync(0, tagsSort: "invalid"));
+        Assert.Equal("tagsSort", exception.ParamName);
+    }
+
+    [Theory]
+    [InlineData("-count")]
+    [InlineData("_id")]
+    [InlineData(null)]
+    public async Task GetAvailableFiltersAsync_ValidTagsSort_CallsApiWithCorrectParameters(string? tagsSort)
+    {
+        // Arrange
+        long collectionId = 123;
+        string? search = "query";
+        var expectedResponse = new AvailableFilters { Result = true };
+        _api.GetAsync(collectionId, tagsSort, search).Returns(expectedResponse);
+
+        // Act
+        var result = await _sut.GetAvailableFiltersAsync(collectionId, tagsSort, search);
+
+        // Assert
+        Assert.Same(expectedResponse, result);
+        await _api.Received(1).GetAsync(collectionId, tagsSort, search);
+    }
+
+    [Fact]
+    public async Task GetAvailableFiltersAsync_WithDefaultParameters_CallsApiWithCorrectParameters()
+    {
+        // Arrange
+        long collectionId = 456;
+        var expectedResponse = new AvailableFilters { Result = true };
+        _api.GetAsync(collectionId, null, null).Returns(expectedResponse);
+
+        // Act
+        var result = await _sut.GetAvailableFiltersAsync(collectionId);
+
+        // Assert
+        Assert.Same(expectedResponse, result);
+        await _api.Received(1).GetAsync(collectionId, null, null);
+    }
+}

--- a/RaindropServer.Tests/FiltersToolsTests.cs
+++ b/RaindropServer.Tests/FiltersToolsTests.cs
@@ -14,24 +14,27 @@ public class FiltersToolsTests
         _sut = new FiltersTools(_api);
     }
 
-    [Fact]
-    public async Task GetAvailableFiltersAsync_InvalidTagsSort_ThrowsArgumentOutOfRangeException()
+    [Theory]
+    [InlineData("invalid")]
+    [InlineData("")]
+    [InlineData(" ")]
+    public async Task GetAvailableFiltersAsync_InvalidTagsSort_ThrowsArgumentOutOfRangeException(string tagsSort)
     {
         // Act & Assert
         var exception = await Assert.ThrowsAsync<ArgumentOutOfRangeException>(() =>
-            _sut.GetAvailableFiltersAsync(0, tagsSort: "invalid"));
+            _sut.GetAvailableFiltersAsync(0, tagsSort: tagsSort));
         Assert.Equal("tagsSort", exception.ParamName);
+        Assert.Contains("Valid values are '-count' or '_id'.", exception.Message);
     }
 
     [Theory]
-    [InlineData("-count")]
-    [InlineData("_id")]
-    [InlineData(null)]
-    public async Task GetAvailableFiltersAsync_ValidTagsSort_CallsApiWithCorrectParameters(string? tagsSort)
+    [InlineData("-count", "query")]
+    [InlineData("_id", null)]
+    [InlineData(null, "query")]
+    public async Task GetAvailableFiltersAsync_ValidParameters_CallsApiWithCorrectParameters(string? tagsSort, string? search)
     {
         // Arrange
         long collectionId = 123;
-        string? search = "query";
         var expectedResponse = new AvailableFilters { Result = true };
         _api.GetAsync(collectionId, tagsSort, search).Returns(expectedResponse);
 


### PR DESCRIPTION
🎯 **What:** The testing gap for `FiltersTools.GetAvailableFiltersAsync` has been addressed.
📊 **Coverage:** 
- Input validation for `tagsSort` (ensuring only `"-count"`, `"_id"`, or `null` are accepted).
- Successful delegation to the `IFiltersApi` dependency with expected parameters (`collectionId`, `tagsSort`, `search`).
- Correct handling of default parameters.
- Verification that the API's return value is correctly passed through.
✨ **Result:** Increased test coverage for `RaindropServer.Filters` logic, ensuring robustness against invalid inputs and correct API integration.

---
*PR created automatically by Jules for task [8836563319671767177](https://jules.google.com/task/8836563319671767177) started by @g1ddy*